### PR TITLE
Feat unplugged profiles

### DIFF
--- a/app/src/main/java/com/example/motounplugged/ui/Screens/ProfilesScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/Screens/ProfilesScreen.kt
@@ -15,9 +15,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 
-
-//import com.example.motounplugged.ui.components.CustomToast
-//import com.example.motounplugged.ui.components.Icon_Edit_Profile
+import com.example.motounplugged.ui.components.CustomToast
+import com.example.motounplugged.ui.components.Icon_Edit_Profile
 
 @Composable
 fun ProfilesScreen(modifier: Modifier = Modifier) {
@@ -80,7 +79,7 @@ fun ProfilesScreen(modifier: Modifier = Modifier) {
                         horizontalArrangement = Arrangement.SpaceBetween
                     ){
                         Text(title, fontWeight = FontWeight.Bold, fontSize = 16.sp, color = Color(0xFF000000))
-//                        Icon_Edit_Profile()
+                        Icon_Edit_Profile()
 
                     }
 
@@ -139,7 +138,7 @@ fun ProfilesScreen(modifier: Modifier = Modifier) {
         }
         if (showToast) {
             Spacer(modifier = Modifier.height(8.dp))
-//            CustomToast("Perfil Ativado")
+            CustomToast("Perfil Ativado")
             LaunchedEffect(Unit) {
                 delay(2000)
                 showToast = false

--- a/app/src/main/java/com/example/motounplugged/ui/Screens/ProfilesScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/Screens/ProfilesScreen.kt
@@ -1,0 +1,155 @@
+package com.example.motounplugged.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+
+
+//import com.example.motounplugged.ui.components.CustomToast
+//import com.example.motounplugged.ui.components.Icon_Edit_Profile
+
+@Composable
+fun ProfilesScreen(modifier: Modifier = Modifier) {
+    var showToast by remember { mutableStateOf(false) }
+
+    val cards = listOf(
+        Pair("Trabalho", 4),
+        Pair("Estudo", 6),
+        Pair("Conforto", 6)
+    )
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+
+    ) {
+        Row (modifier = Modifier
+            .fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center
+        ){
+            Text(
+                text = "Escolha seu foco e organize sua experiência",
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp,
+                fontFamily = FontFamily.SansSerif,
+            )
+
+        }
+
+        Spacer( modifier = Modifier
+            .height(50.dp))
+
+        Column (
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 30.dp)
+        ){
+            Text(text = "Seus Perfis",
+                fontWeight = FontWeight.ExtraBold,
+                fontSize = 13.sp,
+                fontFamily = FontFamily.SansSerif,
+                color = Color.Black
+            )
+        }
+
+
+        cards.forEach { (title, count) ->
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth(0.9f)
+                    .align(Alignment.CenterHorizontally)
+                    .padding(vertical = 12.dp),
+                colors = CardDefaults.cardColors(containerColor = Color(0xFFEFEFEF)),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+            ) {
+                Column(modifier = modifier.padding(16.dp)) {
+                    Row (
+                        modifier = modifier
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ){
+                        Text(title, fontWeight = FontWeight.Bold, fontSize = 16.sp, color = Color(0xFF000000))
+//                        Icon_Edit_Profile()
+
+                    }
+
+                    Spacer(Modifier.height(16.dp))
+                    Text("$count Aplicativos Bloqueados", fontSize = 14.sp, color = Color(0xFF7E7E7E))
+                    Spacer(Modifier.height(16.dp))
+
+                    Button(
+                        onClick = { showToast = true },
+                        modifier = modifier
+                            .fillMaxWidth(0.9f)
+                            .height(40.dp)
+                            .align(Alignment.CenterHorizontally),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color.White,
+                            contentColor = Color.Black
+                        )
+
+                    ) {
+
+                        Text("Ativar Perfil")
+                    }
+                }
+            }
+        }
+
+        Row (
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 10.dp),
+            horizontalArrangement = Arrangement.Center
+        ){
+
+            Button(
+                onClick = {
+                    // tela criar perfil
+                },
+                modifier = Modifier
+                    .fillMaxWidth(0.9f)
+                    .height(40.dp)
+                    .align(Alignment.CenterVertically),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.Black,
+                    contentColor = Color.White)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Add,
+                    contentDescription = "Adicionar"
+                )
+                Spacer(modifier = Modifier
+                    .width(8.dp)
+                )
+                Text(text = "Criar Novo Perfil")
+            }
+
+        }
+        if (showToast) {
+            Spacer(modifier = Modifier.height(8.dp))
+//            CustomToast("Perfil Ativado")
+            LaunchedEffect(Unit) {
+                delay(2000)
+                showToast = false
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ProfilesScreenPreview() {
+    ProfilesScreen()
+}

--- a/app/src/main/java/com/example/motounplugged/ui/components/Icon_profile.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/components/Icon_profile.kt
@@ -1,0 +1,65 @@
+package com.example.motounplugged.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+
+@Composable
+fun Icon_Edit_Profile(
+    modifier: Modifier = Modifier
+) {
+    Row (
+        modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
+
+            //.background(Color(0xFFEEEEEE))
+            .padding(5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp)
+    )
+    {
+        Icon(
+            imageVector = Icons.Default.Edit,
+            contentDescription = "Editar",
+            modifier = modifier
+                .size(16.dp)
+                .clickable {
+                    println("Clicou no icon")
+                }
+        )
+
+
+
+    }
+
+}
+
+@Preview(showBackground = true)
+@Composable
+fun Icon_ProfilePreview() {
+    Column (
+        modifier = Modifier
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon_Edit_Profile()
+
+    }
+
+}

--- a/app/src/main/java/com/example/motounplugged/ui/components/Toast.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/components/Toast.kt
@@ -1,0 +1,50 @@
+package com.example.motounplugged.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+
+
+
+@Composable
+fun CustomToast(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        contentAlignment = Alignment.BottomCenter
+    ) {
+        Row(
+            modifier = Modifier
+                .background(Color(0xFF000000), RoundedCornerShape(12.dp))
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = "Check",
+                tint = Color.White
+            )
+
+            Spacer(Modifier.width(8.dp))
+            Text(message, color = Color.White)
+        }
+    }
+}

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.example.motounplugged.ui.screens.ProfilesScreen
 
 @Composable
 fun AppNavHost(
@@ -30,7 +31,7 @@ fun AppNavHost(
             GenericScreen("Tela Estatísticas")
         }
         composable(AppScreens.Profiles.route) {
-            GenericScreen("Tela Perfis")
+            ProfilesScreen()
         }
         composable(AppScreens.User.route) {
             GenericScreen("Tela Usuário")


### PR DESCRIPTION
## feat: Create unplugged profiles screen and add to NavHost

This PR merges the `feat-unplugged-profiles` branch into `development`, introducing a new screen to display "unplugged" profiles and integrating it into the app's navigation host.

---

### Key Changes:

* ** New Unplugged Profiles Screen:**
    * A dedicated screen was created to list and display profiles that are "unplugged" or offline.
* **NavHost Integration:**
    * The new screen has been successfully added to the application's `NavHost`, making it accessible and navigable from other parts of the app.

---

This enhancement provides users with a new feature to view specific profiles, improving the overall functionality and user experience.

https://github.com/user-attachments/assets/5cdcbc18-4c01-4294-b536-a698ff97074d

