### PR TITLE
Feat: Scheduling Screen

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,22 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-08-27T02:00:37.881732400Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Alien\.android\avd\Pixel_7.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection>
+          <targets>
+            <Target type="DEFAULT_BOOT">
+              <handle>
+                <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Alien\.android\avd\Pixel_API_29.avd" />
+              </handle>
+            </Target>
+          </targets>
+        </DialogSelection>
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+
     }
     kotlinOptions {
         jvmTarget = "11"
@@ -50,6 +51,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.places)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -57,4 +59,5 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
 }

--- a/app/src/main/java/com/example/motounplugged/MainActivity.kt
+++ b/app/src/main/java/com/example/motounplugged/MainActivity.kt
@@ -13,8 +13,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             MotoUnpluggedTheme {
-                ScheduleScreen()
-                //MotoUnpluggedApp()
+                MotoUnpluggedApp()
             }
         }
     }

--- a/app/src/main/java/com/example/motounplugged/MainActivity.kt
+++ b/app/src/main/java/com/example/motounplugged/MainActivity.kt
@@ -4,6 +4,8 @@ package com.example.motounplugged
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import com.example.motounplugged.ui.screens.ProfilesScreen
+import com.example.motounplugged.ui.screens.ScheduleScreen
 import com.example.motounplugged.ui.theme.MotoUnpluggedTheme
 
 class MainActivity : ComponentActivity() {
@@ -11,7 +13,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             MotoUnpluggedTheme {
-                MotoUnpluggedApp()
+                ScheduleScreen()
+                //MotoUnpluggedApp()
             }
         }
     }

--- a/app/src/main/java/com/example/motounplugged/ui/Screens/ScheludeScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/Screens/ScheludeScreen.kt
@@ -1,0 +1,206 @@
+package com.example.motounplugged.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import android.app.TimePickerDialog
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+
+
+@Composable
+fun ScheduleScreen() {
+    val weekDays = listOf("Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab")
+    val selectedDays = remember { mutableStateListOf<String>() }
+
+    var time by remember { mutableStateOf(LocalTime.of(0, 0)) }
+    var durationHours by remember { mutableStateOf(0) }
+    var durationMinutes by remember { mutableStateOf(0) }
+    var selectedProfile by remember { mutableStateOf("") }
+
+    val profiles = listOf("Profile 1", "Profile 2", "Profile 3")
+    val scheduledSessions = listOf(
+        "Monday to Friday\n08:00 - 30 min",
+        "Saturday\n19:00 - 1 hour"
+    )
+
+    var showTimePicker by remember { mutableStateOf(false) }
+    var showDurationPicker by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Agendamento", fontWeight=FontWeight.Bold, fontSize = 18.sp, fontFamily = FontFamily.SansSerif )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Weekdays selection
+        Row(horizontalArrangement = Arrangement.SpaceEvenly, modifier = Modifier.fillMaxWidth()) {
+            weekDays.forEach { day ->
+                val isSelected = selectedDays.contains(day)
+                Button(
+                    onClick = {
+                        if (isSelected) selectedDays.remove(day) else selectedDays.add(day)
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = if (isSelected) Color.Gray else Color.LightGray
+                    ),
+                    shape = CircleShape
+                ) {
+                    Text(day)
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Time
+        Text("Hora", fontWeight=FontWeight.Bold, fontSize = 18.sp, fontFamily = FontFamily.SansSerif)
+        Text(time.format(DateTimeFormatter.ofPattern("HH:mm")))
+        Button(onClick = { showTimePicker = true }, colors = ButtonDefaults.buttonColors(Color.Gray)) {
+            Text("Select time", fontWeight=FontWeight.Bold, fontFamily = FontFamily.SansSerif)
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Duration
+        Text("Duração", fontWeight=FontWeight.Bold, fontSize = 18.sp, fontFamily = FontFamily.SansSerif)
+        Text(
+            String.format("%02d:%02d", durationHours, durationMinutes),
+            style = MaterialTheme.typography.displayMedium
+        )
+        Button(onClick = { showDurationPicker = true }, colors = ButtonDefaults.buttonColors(Color.Gray)) {
+            Text("Selecione a duração.", fontWeight=FontWeight.Bold, fontFamily = FontFamily.SansSerif)
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Profile selection
+        var dropdownExpanded by remember { mutableStateOf(false) }
+        Box {
+            OutlinedButton(onClick = { dropdownExpanded = true }) {
+                Text(selectedProfile.ifEmpty { "Escolha um perfil" })
+            }
+            DropdownMenu(expanded = dropdownExpanded, onDismissRequest = { dropdownExpanded = false }) {
+                profiles.forEach { profile ->
+                    DropdownMenuItem(
+                        text = { Text(profile) },
+                        onClick = {
+                            selectedProfile = profile
+                            dropdownExpanded = false
+                        }
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Schedule button
+        Button(
+            onClick = { /* Logic to schedule session */ },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = selectedProfile.isNotEmpty()
+        ) {
+            Text("Agendar Sessão", fontWeight=FontWeight.Bold, fontSize = 18.sp, fontFamily = FontFamily.SansSerif)
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Scheduled sessions
+        Text("Sessões Agendadads", fontWeight=FontWeight.Bold, fontSize = 18.sp, fontFamily = FontFamily.SansSerif)
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        scheduledSessions.forEach { session ->
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp),
+                shape = RoundedCornerShape(12.dp),
+                elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(session)
+                    Box(
+                        modifier = Modifier
+                            .size(12.dp)
+                            .background(Color.Green, shape = CircleShape)
+                    )
+                }
+            }
+        }
+    }
+
+    // TimePicker (using AndroidView)
+    if (showTimePicker) {
+        val context = LocalContext.current
+        LaunchedEffect(Unit) {
+            TimePickerDialog(
+                context,
+                { _, hour, minute ->
+                    time = LocalTime.of(hour, minute)
+                    showTimePicker = false
+                },
+                time.hour,
+                time.minute,
+                true
+            ).show()
+        }
+    }
+
+    // DurationPicker (simulated with sliders)
+    if (showDurationPicker) {
+        AlertDialog(
+            onDismissRequest = { showDurationPicker = false },
+            confirmButton = {
+                Button(onClick = { showDurationPicker = false }) {
+                    Text("OK")
+                }
+            },
+            title = { Text("Selecione a Duração") },
+            text = {
+                Column {
+                    Text("Horas: $durationHours")
+                    Slider(
+                        value = durationHours.toFloat(),
+                        onValueChange = { durationHours = it.toInt() },
+                        valueRange = 0f..12f,
+                        steps = 11
+                    )
+                    Text("Minutos: $durationMinutes")
+                    Slider(
+                        value = durationMinutes.toFloat(),
+                        onValueChange = { durationMinutes = it.toInt() },
+                        valueRange = 0f..59f,
+                        steps = 58
+                    )
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/example/motounplugged/ui/Screens/ScheludeScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/Screens/ScheludeScreen.kt
@@ -10,21 +10,24 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
+
 
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import android.app.TimePickerDialog
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.viewinterop.AndroidView
+
 
 
 @Composable
 fun ScheduleScreen() {
+    val scrollState = rememberScrollState()
     val weekDays = listOf("Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab")
     val selectedDays = remember { mutableStateListOf<String>() }
 
@@ -35,8 +38,8 @@ fun ScheduleScreen() {
 
     val profiles = listOf("Profile 1", "Profile 2", "Profile 3")
     val scheduledSessions = listOf(
-        "Monday to Friday\n08:00 - 30 min",
-        "Saturday\n19:00 - 1 hour"
+        "Segunda a Sexta \n08:00 - 30 min",
+        "Sábado \n19:00 - 1 hour"
     )
 
     var showTimePicker by remember { mutableStateOf(false) }
@@ -45,15 +48,20 @@ fun ScheduleScreen() {
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(scrollState) // habilita o scroll
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text("Agendamento", fontWeight=FontWeight.Bold, fontSize = 18.sp, fontFamily = FontFamily.SansSerif )
+        Text("Agendamento", fontWeight=FontWeight.Bold,
+            fontSize = 20.sp,
+            fontFamily = FontFamily.SansSerif )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(8.dp))
 
         // Weekdays selection
-        Row(horizontalArrangement = Arrangement.SpaceEvenly, modifier = Modifier.fillMaxWidth()) {
+        Row(modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
             weekDays.forEach { day ->
                 val isSelected = selectedDays.contains(day)
                 Button(
@@ -63,32 +71,55 @@ fun ScheduleScreen() {
                     colors = ButtonDefaults.buttonColors(
                         containerColor = if (isSelected) Color.Gray else Color.LightGray
                     ),
-                    shape = CircleShape
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                                .width(44.dp)
+                                .height(38.dp),
+                    contentPadding = PaddingValues(0.dp),
+                    shape = RoundedCornerShape(20.dp)
                 ) {
-                    Text(day)
+                    Text(day, fontSize = 16.sp)
                 }
             }
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(20.dp))
 
         // Time
-        Text("Hora", fontWeight=FontWeight.Bold, fontSize = 18.sp, fontFamily = FontFamily.SansSerif)
-        Text(time.format(DateTimeFormatter.ofPattern("HH:mm")))
-        Button(onClick = { showTimePicker = true }, colors = ButtonDefaults.buttonColors(Color.Gray)) {
-            Text("Select time", fontWeight=FontWeight.Bold, fontFamily = FontFamily.SansSerif)
+        Text("Hora",
+            fontWeight=FontWeight.Bold,
+            fontSize = 20.sp,
+            fontFamily = FontFamily.SansSerif)
+
+        Text(text = time.format(DateTimeFormatter.ofPattern("HH:mm")),
+            fontWeight = FontWeight.Bold,
+            fontSize = 36.sp,
+            fontFamily = FontFamily.SansSerif)
+
+        Button(onClick = { showTimePicker = true },
+            colors = ButtonDefaults.buttonColors(Color.Gray)) {
+            Text("Selecione a Hora",
+                fontWeight= FontWeight.Bold,
+                fontFamily = FontFamily.SansSerif)
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         // Duration
-        Text("Duração", fontWeight=FontWeight.Bold, fontSize = 18.sp, fontFamily = FontFamily.SansSerif)
+        Text("Duração",
+            fontWeight = FontWeight.Bold,
+            fontSize = 20.sp,
+            fontFamily = FontFamily.SansSerif)
         Text(
             String.format("%02d:%02d", durationHours, durationMinutes),
-            style = MaterialTheme.typography.displayMedium
+            fontWeight = FontWeight.Bold,
+            fontSize = 36.sp,
+            fontFamily = FontFamily.SansSerif
         )
-        Button(onClick = { showDurationPicker = true }, colors = ButtonDefaults.buttonColors(Color.Gray)) {
-            Text("Selecione a duração.", fontWeight=FontWeight.Bold, fontFamily = FontFamily.SansSerif)
+        Button(onClick = { showDurationPicker = true },
+            colors = ButtonDefaults.buttonColors(Color.Gray)) {
+            Text("Selecione a duração",
+                fontWeight = FontWeight.Bold,
+                fontFamily = FontFamily.SansSerif)
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
@@ -26,10 +26,11 @@ fun AppNavHost(
             GenericScreen("Tela Início")
         }
         composable(AppScreens.Schedule.route) {
-            GenericScreen("Tela Agendar")
+            ScheduleScreen()
         }
         composable(AppScreens.Stats.route) {
-            ScheduleScreen()
+            GenericScreen("Tela estatisticas")
+
         }
         composable(AppScreens.Profiles.route) {
             ProfilesScreen()

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
@@ -10,6 +10,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.example.motounplugged.ui.screens.ProfilesScreen
+import com.example.motounplugged.ui.screens.ScheduleScreen
 
 @Composable
 fun AppNavHost(
@@ -28,7 +29,7 @@ fun AppNavHost(
             GenericScreen("Tela Agendar")
         }
         composable(AppScreens.Stats.route) {
-            GenericScreen("Tela Estatísticas")
+            ScheduleScreen()
         }
         composable(AppScreens.Profiles.route) {
             ProfilesScreen()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+places = "4.4.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +25,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+places = { group = "com.google.android.libraries.places", name = "places", version.ref = "places" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# feat: Design Scheduling Screen and add to NavHost

This PR merges the branch `feat-scheduling-screen` to the branch `development`, introducing the scheduling screen, where the user can create Unplugged Sessions and adding an access to this screen on the sidebar.

## Key Changes

- **New Scheduling Screen** : A screen was created to allow users to schedule their unplugged sessions
- **NavHost Integration** : This screen can now be accessed by the NavHost functions


https://github.com/user-attachments/assets/db4dc57f-f43a-419a-a572-264f259533ab


