### PR TITLE
feat: Implement "Select Apps" screen for application management

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -21,9 +21,6 @@
           </targets>
         </DialogSelection>
       </SelectionState>
-      <SelectionState runConfigName="Homescreen">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
+    implementation("io.coil-kt:coil-compose:2.6.0")
+
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+
+
     <application
         android:name=".MotoUnpluggedApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/example/motounplugged/MotoUnpluggedApp.kt
+++ b/app/src/main/java/com/example/motounplugged/MotoUnpluggedApp.kt
@@ -33,6 +33,7 @@ fun MotoUnpluggedApp() {
         selectedRoute in listOf(  //lista de rotas secundarias
             AppScreens.CreateProfile.route,
             "edit_profile/{profileTitle}",
+            AppScreens.SelectApps.route,
 
 
             )

--- a/app/src/main/java/com/example/motounplugged/MotoUnpluggedApplication.kt
+++ b/app/src/main/java/com/example/motounplugged/MotoUnpluggedApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.example.motounplugged.di.databaseModule
 import com.example.motounplugged.di.repositoryModule
 import com.example.motounplugged.di.viewModelModule
+import com.example.motounplugged.di.useCaseModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.GlobalContext.startKoin
 
@@ -13,7 +14,7 @@ class MotoUnpluggedApplication : Application() {
 
         startKoin{
             androidContext(this@MotoUnpluggedApplication)
-            modules(listOf(databaseModule,repositoryModule, viewModelModule))
+            modules(listOf(databaseModule,repositoryModule, viewModelModule,useCaseModule))
         }
     }
 

--- a/app/src/main/java/com/example/motounplugged/di/KoinModules.kt
+++ b/app/src/main/java/com/example/motounplugged/di/KoinModules.kt
@@ -3,11 +3,16 @@ package com.example.motounplugged.di
 import androidx.room.Room
 import com.example.motounplugged.database.MotoUnpluggedDataBase
 import com.example.motounplugged.database.entities.ProfilesEntity
+import com.example.motounplugged.domain.usecase.GetInstalledAppsUseCase
 import com.example.motounplugged.repositories.ProfileRepository
 import com.example.motounplugged.ui.features.createprofile.CreateProfileViewModel
 import com.example.motounplugged.ui.features.profiles.ProfilesScreenViewModel
+import com.example.motounplugged.ui.features.selectapps.SelectAppsViewModel
+
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.android.ext.koin.androidApplication
+
 //import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import org.koin.androidx.compose.koinViewModel
@@ -34,7 +39,15 @@ val repositoryModule = module {
     }
 }
 
+val useCaseModule = module {
+    // Koin vai prover o Context para criar o Use Case
+    factory { GetInstalledAppsUseCase(androidApplication()) }
+}
+
 val viewModelModule = module {
+    viewModel {
+        SelectAppsViewModel(get())
+    }
     viewModel {
         CreateProfileViewModel(get())
     }

--- a/app/src/main/java/com/example/motounplugged/di/KoinModules.kt
+++ b/app/src/main/java/com/example/motounplugged/di/KoinModules.kt
@@ -40,7 +40,6 @@ val repositoryModule = module {
 }
 
 val useCaseModule = module {
-    // Koin vai prover o Context para criar o Use Case
     factory { GetInstalledAppsUseCase(androidApplication()) }
 }
 

--- a/app/src/main/java/com/example/motounplugged/domain/usecase/GetInstalledAppsUseCase.kt
+++ b/app/src/main/java/com/example/motounplugged/domain/usecase/GetInstalledAppsUseCase.kt
@@ -1,0 +1,26 @@
+// domain/usecase/GetInstalledAppsUseCase.kt
+package com.example.motounplugged.domain.usecase
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import com.example.motounplugged.models.AppInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class GetInstalledAppsUseCase(private val context: Context) {
+
+    suspend fun execute(): List<AppInfo> = withContext(Dispatchers.IO) {
+        val packageManager = context.packageManager
+        val apps = packageManager.getInstalledApplications(PackageManager.GET_META_DATA)
+        apps.filter { it.flags and ApplicationInfo.FLAG_SYSTEM == 0 } // Filtra apps de sistema
+            .map {
+                AppInfo(
+                    name = it.loadLabel(packageManager).toString(),
+                    packageName = it.packageName,
+                    icon = it.loadIcon(packageManager)
+                )
+            }
+            .sortedBy { it.name.lowercase() } // Ordena por nome
+    }
+}

--- a/app/src/main/java/com/example/motounplugged/models/AppInfo.kt
+++ b/app/src/main/java/com/example/motounplugged/models/AppInfo.kt
@@ -1,0 +1,9 @@
+package com.example.motounplugged.models
+
+import android.graphics.drawable.Drawable
+
+data class AppInfo(
+    val name: String,
+    val packageName: String,
+    val icon: Drawable
+)

--- a/app/src/main/java/com/example/motounplugged/ui/components/AppListItem.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/components/AppListItem.kt
@@ -1,0 +1,41 @@
+// ui/components/AppListItem.kt
+package com.example.motounplugged.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.motounplugged.models.AppInfo
+
+@Composable
+fun AppListItem(
+    appInfo: AppInfo,
+    isSelected: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!isSelected) }
+            .padding(vertical = 8.dp, horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsyncImage(
+            model = appInfo.icon,
+            contentDescription = "${appInfo.name} icon",
+            modifier = Modifier.size(40.dp)
+        )
+        Spacer(Modifier.width(16.dp))
+        Text(text = appInfo.name, modifier = Modifier.weight(1f))
+        Checkbox(
+            checked = isSelected,
+            onCheckedChange = { onCheckedChange(it) }
+        )
+    }
+}

--- a/app/src/main/java/com/example/motounplugged/ui/features/createprofile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/createprofile/CreateProfileScreen.kt
@@ -90,8 +90,7 @@ private fun CreateProfileContent(
         // Card para selecionar apps
         Card(
             shape = RoundedCornerShape(16.dp),
-
-            modifier = Modifier.clickable {//navController.navigate(AppScreens.Lista de Apps.route
+            modifier = Modifier.clickable {navController.navigate(AppScreens.SelectApps.route)
             }
         ) {
             Row(

--- a/app/src/main/java/com/example/motounplugged/ui/features/selectapps/SelectAppsScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/selectapps/SelectAppsScreen.kt
@@ -58,7 +58,7 @@ fun SelectAppsScreen(
                 modifier = Modifier.padding(top = 16.dp)
             )
             Text(
-                text = "Selecione os apps permitidos na sessão Moto Unplugged",
+                text = "Selecione os apps permitidos ",
                 fontStyle = FontStyle.Normal,
                 fontSize = 20.sp,
                 color = Color.Gray,

--- a/app/src/main/java/com/example/motounplugged/ui/features/selectapps/SelectAppsScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/selectapps/SelectAppsScreen.kt
@@ -1,0 +1,118 @@
+// ui/features/selectapps/SelectAppsScreen.kt
+package com.example.motounplugged.ui.features.selectapps
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import org.koin.androidx.compose.koinViewModel
+import com.example.motounplugged.ui.components.AppListItem
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SelectAppsScreen(
+    navController: NavController,
+    viewModel: SelectAppsViewModel = koinViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.navigationEvent.collect { event ->
+            when (event) {
+                is SelectAppsNavigationEvent.NavigateBackWithResult -> {
+                    // Envia o resultado para a tela anterior
+                    navController.previousBackStackEntry
+                        ?.savedStateHandle
+                        ?.set("selected_apps", event.selectedApps)
+                    navController.popBackStack()
+                }
+            }
+        }
+    }
+
+        Column(modifier = Modifier.padding(2.dp),
+                horizontalAlignment = Alignment.CenterHorizontally) {
+
+            Column (  modifier = Modifier.padding(2.dp),
+                horizontalAlignment = Alignment.CenterHorizontally)
+            {
+            // Textos de Título e Subtítulo
+            Text(
+                text = "Aplicativos Permitidos",
+                fontStyle = FontStyle.Normal,
+                fontSize = 25.sp,
+                color = Color.Black,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(top = 16.dp)
+            )
+            Text(
+                text = "Selecione os apps permitidos na sessão Moto Unplugged",
+                fontStyle = FontStyle.Normal,
+                fontSize = 20.sp,
+                color = Color.Gray,
+                modifier = Modifier.padding(top = 5.dp, bottom = 16.dp)
+            )
+            }
+            // Search Bar
+            OutlinedTextField(
+                value = uiState.searchQuery,
+                onValueChange = { viewModel.onEvent(SelectAppsEvent.OnSearchQueryChange(it)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                placeholder = { Text("Search app") },
+                leadingIcon = { Icon(Icons.Default.Search, null) },
+                singleLine = true
+            )
+
+            // Select All
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text("Select all", style = MaterialTheme.typography.bodyLarge)
+                Checkbox(
+                    checked = uiState.filteredApps.isNotEmpty() && uiState.selectedAppPackages.containsAll(uiState.filteredApps.map { it.packageName }),
+                    onCheckedChange = { viewModel.onEvent(SelectAppsEvent.OnSelectAllClick) }
+                )
+            }
+
+            Divider(modifier = Modifier.padding(vertical = 8.dp))
+
+            if (uiState.isLoading) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(
+                        items = uiState.filteredApps,
+                        key = { it.packageName }
+                    ) { app ->
+                        AppListItem(
+                            appInfo = app,
+                            isSelected = uiState.selectedAppPackages.contains(app.packageName),
+                            onCheckedChange = { isSelected ->
+                                viewModel.onEvent(SelectAppsEvent.OnAppSelectionChange(app.packageName, isSelected))
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }

--- a/app/src/main/java/com/example/motounplugged/ui/features/selectapps/SelectAppsScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/selectapps/SelectAppsScreen.kt
@@ -1,9 +1,11 @@
 // ui/features/selectapps/SelectAppsScreen.kt
 package com.example.motounplugged.ui.features.selectapps
 
+import android.content.res.Resources
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Search
@@ -19,6 +21,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import org.koin.androidx.compose.koinViewModel
 import com.example.motounplugged.ui.components.AppListItem
+import kotlin.math.round
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -73,8 +76,16 @@ fun SelectAppsScreen(
                     .fillMaxWidth()
                     .padding(16.dp),
                 placeholder = { Text("Search app") },
+                shape = RoundedCornerShape(30.dp),
                 leadingIcon = { Icon(Icons.Default.Search, null) },
-                singleLine = true
+                singleLine = true ,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedContainerColor = com.example.motounplugged.ui.theme.Gray20, // Fill color when focused
+                    focusedBorderColor = com.example.motounplugged.ui.theme.Gray20,
+                    unfocusedContainerColor = com.example.motounplugged.ui.theme.Gray20,  // Fill color when not focused
+                    unfocusedBorderColor = com.example.motounplugged.ui.theme.Gray20
+
+                )
             )
 
             // Select All

--- a/app/src/main/java/com/example/motounplugged/ui/features/selectapps/SelectAppsViewModel.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/selectapps/SelectAppsViewModel.kt
@@ -23,13 +23,13 @@ data class SelectAppsUiState(
 }
 
 sealed interface SelectAppsEvent {
-    // Evento para quando o texto da busca muda, carregando a nova 'query'
+    // Evento para o texto da busca
     data class OnSearchQueryChange(val query: String) : SelectAppsEvent
 
-    // Evento para quando um checkbox de app é marcado/desmarcado
+    // Evento checkbox de app é marcado/desmarcado
     data class OnAppSelectionChange(val packageName: String, val isSelected: Boolean) : SelectAppsEvent
 
-    // Evento para o clique no checkbox "Selecionar Tudo"
+    // Evento para checkbox "Selecionar Tudo"
     data object OnSelectAllClick : SelectAppsEvent
 
     // Evento para o clique no botão Salvar
@@ -57,7 +57,6 @@ class SelectAppsViewModel(
         }
     }
 
-    // ESTE BLOCO 'when' AGORA VAI FUNCIONAR, POIS TODOS OS CASOS ESTÃO DEFINIDOS ACIMA
     fun onEvent(event: SelectAppsEvent) {
         when (event) {
             is SelectAppsEvent.OnSearchQueryChange -> _uiState.update { it.copy(searchQuery = event.query) }

--- a/app/src/main/java/com/example/motounplugged/ui/features/selectapps/SelectAppsViewModel.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/selectapps/SelectAppsViewModel.kt
@@ -1,0 +1,95 @@
+package com.example.motounplugged.ui.features.selectapps
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.motounplugged.models.AppInfo
+import com.example.motounplugged.domain.usecase.GetInstalledAppsUseCase
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+
+data class SelectAppsUiState(
+    val allApps: List<AppInfo> = emptyList(),
+    val searchQuery: String = "",
+    val selectedAppPackages: Set<String> = emptySet(),
+    val isLoading: Boolean = true
+) {
+    val filteredApps: List<AppInfo>
+        get() = if (searchQuery.isBlank()) {
+            allApps
+        } else {
+            allApps.filter { it.name.contains(searchQuery, ignoreCase = true) }
+        }
+}
+
+sealed interface SelectAppsEvent {
+    // Evento para quando o texto da busca muda, carregando a nova 'query'
+    data class OnSearchQueryChange(val query: String) : SelectAppsEvent
+
+    // Evento para quando um checkbox de app é marcado/desmarcado
+    data class OnAppSelectionChange(val packageName: String, val isSelected: Boolean) : SelectAppsEvent
+
+    // Evento para o clique no checkbox "Selecionar Tudo"
+    data object OnSelectAllClick : SelectAppsEvent
+
+    // Evento para o clique no botão Salvar
+    data object OnSaveClick : SelectAppsEvent
+}
+
+sealed interface SelectAppsNavigationEvent {
+    data class NavigateBackWithResult(val selectedApps: List<String>) : SelectAppsNavigationEvent
+}
+
+class SelectAppsViewModel(
+    private val getInstalledAppsUseCase: GetInstalledAppsUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SelectAppsUiState())
+    val uiState: StateFlow<SelectAppsUiState> = _uiState.asStateFlow()
+
+    private val _navigationEvent = Channel<SelectAppsNavigationEvent>()
+    val navigationEvent = _navigationEvent.receiveAsFlow()
+
+    init {
+        viewModelScope.launch {
+            val apps = getInstalledAppsUseCase.execute()
+            _uiState.update { it.copy(allApps = apps, isLoading = false) }
+        }
+    }
+
+    // ESTE BLOCO 'when' AGORA VAI FUNCIONAR, POIS TODOS OS CASOS ESTÃO DEFINIDOS ACIMA
+    fun onEvent(event: SelectAppsEvent) {
+        when (event) {
+            is SelectAppsEvent.OnSearchQueryChange -> _uiState.update { it.copy(searchQuery = event.query) }
+            is SelectAppsEvent.OnAppSelectionChange -> {
+                _uiState.update { currentState ->
+                    val newSelection = currentState.selectedAppPackages.toMutableSet()
+                    if (event.isSelected) newSelection.add(event.packageName)
+                    else newSelection.remove(event.packageName)
+                    currentState.copy(selectedAppPackages = newSelection)
+                }
+            }
+            SelectAppsEvent.OnSelectAllClick -> {
+                _uiState.update { currentState ->
+                    val filteredPackages = currentState.filteredApps.map { it.packageName }.toSet()
+                    val currentSelection = currentState.selectedAppPackages
+                    val newSelection = if (currentSelection.containsAll(filteredPackages)) {
+                        currentSelection - filteredPackages
+                    } else {
+                        currentSelection + filteredPackages
+                    }
+                    currentState.copy(selectedAppPackages = newSelection)
+                }
+            }
+            SelectAppsEvent.OnSaveClick -> {
+                viewModelScope.launch {
+                    _navigationEvent.send(
+                        SelectAppsNavigationEvent.NavigateBackWithResult(
+                            _uiState.value.selectedAppPackages.toList()
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
@@ -17,6 +17,7 @@ import com.example.motounplugged.ui.features.settings.SettingsScreen
 import com.example.motounplugged.ui.features.stats.StatsScreen
 import com.example.motounplugged.ui.features.streak.StreakScreen
 import com.example.motounplugged.ui.features.user.UserScreen
+import com.example.motounplugged.ui.features.selectapps.SelectAppsScreen
 import org.koin.androidx.compose.koinViewModel
 
 
@@ -54,6 +55,9 @@ fun AppNavHost(
         }
         composable(AppScreens.CreateProfile.route) {
             CreateProfileScreen(navController = navController)
+        }
+        composable(AppScreens.SelectApps.route) {
+            SelectAppsScreen(navController = navController)
         }
     }
 }

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/AppScreens.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/AppScreens.kt
@@ -10,4 +10,5 @@ sealed class AppScreens(val route: String) {
     object Settings : AppScreens("settings")
     object Streak : AppScreens("streak")
     object CreateProfile : AppScreens("create_profile")
+    object SelectApps : AppScreens("select_apps")
 }

--- a/app/src/main/java/com/example/motounplugged/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/theme/Color.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 val Purple80 = Color(0xFFD0BCFF)
 val PurpleGrey80 = Color(0xFFCCC2DC)
 val Pink80 = Color(0xFFEFB8C8)
+val Gray20 = Color(0xFFE8EAF6)
 
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)


### PR DESCRIPTION

This PR introduces the new **Select Apps** screen, allowing users to view a list of installed applications and interact with them. This feature required the integration of new dependencies, permissions, and a complete architectural setup using MVVM/Use Cases and Koin.

---

### Key Changes and Features:




* **New Feature Screen:**
    * Implemented the **SelectApps screen**, providing the UI to display installed applications.
    * Added the **SelectApps screen to the NavHost** and **fixed navigation** to it.
* **Application Logic & Data:**
    * Created the **`GetInstalledAppsUseCase`** to handle the logic for fetching the list of applications installed on the device.
    * Implemented the **`SelectAppsViewModel`** to manage the screen state and selection logic.
    * Introduced the **`AppInfo` data class** to structure and hold application data (name, icon, etc.).
* **UI Components & Dependencies:**
    * Added the **Coil Compose library** for efficient and asynchronous loading of application icons.
    * Created the reusable **`AppListItem` Composable** to display each application in the list.
* **Permissions & Configuration:**
    * Added the **`QUERY_ALL_PACKAGES` permission** to the manifest, which is necessary to access the list of all installed apps on Android 11+.
    * Updated the **Koin module** to include the new `SelectAppsViewModel` and `GetInstalledAppsUseCase`.
* **Cleanup:**
    * Removed the obsolete `Homescreen` run configuration.

---
https://github.com/user-attachments/assets/4bbe9c6a-1a24-4d17-84c3-657227a34371

