### PR TITLE
Feat: Implement "Home Screen" with mocked data

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -21,6 +21,9 @@
           </targets>
         </DialogSelection>
       </SelectionState>
+      <SelectionState runConfigName="HomeScreenPreview">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/com/example/motounplugged/ui/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/home/HomeScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -39,12 +40,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 import androidx.navigation.NavController
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.example.motounplugged.ui.navigation.AppScreens
 import com.example.motounplugged.ui.theme.MotoUnpluggedTheme
 
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    navController: NavHostController
 ){
     Column (
         modifier = modifier
@@ -78,6 +83,9 @@ fun HomeScreen(
             )
         }
 
+        Spacer(modifier = Modifier
+            .height(30.dp))
+
 
        //card de perfis
         OutlinedCard (
@@ -105,7 +113,8 @@ fun HomeScreen(
 
                 ElevatedButton(onClick = { onClick() },
                     modifier = Modifier
-                        .padding(horizontal = 10.dp)) {
+                        .padding(horizontal = 10.dp)
+                        .padding(top = 2.dp)) {
                     Text(
                         text = "Ativo",
                         fontWeight = FontWeight.Bold,
@@ -186,7 +195,7 @@ fun HomeScreen(
                     }
                     Row {
                         Text(
-                            text = "14:00 -16:00",
+                            text = "14:00 - 16:00",
                             fontSize = 10.sp,
                             fontStyle = FontStyle.Italic,
                             color = Color.Gray,
@@ -198,21 +207,180 @@ fun HomeScreen(
                     }
 
 
-
                 }
 
             }
+
+        OutlinedCard (
+            border = BorderStroke(1.dp,Color.Black),
+            modifier = Modifier
+                .size(width = 350.dp, height = 160.dp)
+                .align(Alignment.CenterHorizontally)
+                .padding(top = 30.dp)
+        ){
+            Row {
+                Text(
+                    text = "Estastísticas",
+                    fontStyle = FontStyle.Italic,
+                    fontSize = 20.sp,
+                    color = Color.Black,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier
+                        .padding(16.dp)
+                )
+
+                Spacer(
+                    modifier = Modifier
+                        .weight(1f)
+                )
+
+                ElevatedButton(onClick = { onClick() },
+                    modifier = Modifier
+                        .size(width = 130.dp, height = 45.dp)
+                        .padding(end = 15.dp, top = 10.dp)
+                ) {
+                    Text(
+                        text = "Ver mais",
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 10.sp,
+                        fontStyle = FontStyle.Normal,
+                        color = Color.Black,
+                        modifier = Modifier
+                            .padding(1.dp)
+                    )
+                }
+            }
+
+
+            Row {
+
+                Text(
+                    text = "3h 42m",
+                    fontSize = 15.sp,
+                    fontStyle = FontStyle.Italic,
+                    color = Color.Black,
+                    modifier = Modifier
+                        .padding(start = 100.dp)
+                )
+
+                Spacer(
+                    modifier = Modifier
+                        .weight(1f)
+                )
+
+                Text(
+                    text = "45 min ",
+                    fontSize = 15.sp,
+                    fontStyle = FontStyle.Italic,
+                    color = Color.Black,
+                    modifier = Modifier
+                        .padding(end = 100.dp)
+                )
+            }
+            Row (
+                modifier = Modifier
+                    .padding(top = 5.dp)
+            ){
+
+                Text(
+                    text = "Hoje",
+                    fontSize = 10.sp,
+                    fontStyle = FontStyle.Italic,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.Black,
+                    modifier = Modifier
+                        .padding(start = 110.dp)
+                )
+
+                Spacer(
+                    modifier = Modifier
+                        .weight(1f)
+                )
+
+                Text(
+                    text = "Média",
+                    fontSize = 10.sp,
+                    fontStyle = FontStyle.Italic,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.Black,
+                    modifier = Modifier
+                        .padding(end = 115.dp)
+                )
+            }
+        }
+
+        OutlinedCard (
+            border = BorderStroke(1.dp,Color.Black),
+            modifier = Modifier
+                .size(width = 350.dp, height = 190.dp)
+                .align(Alignment.CenterHorizontally)
+                .padding(top = 30.dp)
+        ){
+            Row {
+                Text(
+                    text = "Acesso rápido",
+                    fontStyle = FontStyle.Italic,
+                    fontSize = 20.sp,
+                    color = Color.Black,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier
+                        .padding(16.dp)
+                )
+            }
+           ElevatedButton(
+               onClick = { navController.navigate(AppScreens.Profiles.route) },
+               modifier = Modifier
+                   .padding(top = 5.dp)
+                   .padding(start = 15.dp)
+                   .size(width = 320.dp, height = 40.dp)
+           ) {
+               Text(
+                   text = "Gerenciar Perfis",
+                   fontWeight = FontWeight.Bold,
+                   fontSize = 10.sp,
+                   fontStyle = FontStyle.Normal,
+                   color = Color.Black,
+                   modifier = Modifier
+                       .padding(1.dp)
+               )
+           }
+            ElevatedButton(
+                onClick = { navController.navigate(AppScreens.Schedule.route) },
+                modifier = Modifier
+                    .padding(top = 10.dp)
+                    .padding(start = 15.dp)
+                    .size(width = 320.dp, height = 40.dp)
+            ) {
+                Text(
+                    text = "Agendar",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 10.sp,
+                    fontStyle = FontStyle.Normal,
+                    color = Color.Black,
+                    modifier = Modifier
+                        .padding(1.dp)
+                )
+            }
+        }
+
+
+
 
 
         }
     }
 
-@Preview(showBackground = true
-)
+@Preview(showBackground = true)
 @Composable
-private fun Homescreen(){
+private fun HomeScreenPreview() {
     MotoUnpluggedTheme {
-        HomeScreen(onClick = {})
+        val navController = rememberNavController()
+        HomeScreen(
+            navController = navController,
+            onClick = {}
+        )
     }
-
 }
+
+
+

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
@@ -31,7 +31,7 @@ fun AppNavHost(
         modifier = modifier
     ) {
         composable(AppScreens.Home.route) {
-            HomeScreen(onClick = {})
+            HomeScreen( navController = navController,onClick = {})
         }
         composable(AppScreens.Schedule.route) {
             ScheduleScreen()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.1"
+agp = "8.10.1"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"


### PR DESCRIPTION
This PR introduces a new screen, the **Home Screen**, using mocked data and providing an initial preview of what the app’s main screen will look like.

***
Key Changes and Features:

**New Feature Screen:**

- Implemented the Home Screen, providing the initial UI layout for the app.

- Added the Home Screen to the NavHost and set up navigation between screens.

**UI & Mocked Data:**

- Used mocked data to visualize the main content structure and components of the Home Screen.

- Created placeholder Composables to represent future content and actions on the screen.

**Navigation:**

- Configured navigation actions in the NavHost to enable smooth transitions from the Home Screen to other parts of the app.

**Cleanup:**

- Removed any temporary placeholders or unused preview configurations related to initial screen setup.