### PR TITLE
Feat/create blocked session

### DIFF
--- a/app/src/main/java/com/example/motounplugged/database/MotoUnpluggedDataBase.kt
+++ b/app/src/main/java/com/example/motounplugged/database/MotoUnpluggedDataBase.kt
@@ -47,10 +47,6 @@ import kotlinx.coroutines.launch
                     .addCallback(object : Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {
                             super.onCreate(db)
-                            CoroutineScope(Dispatchers.IO).launch {
-                                // Use o instance diretamente, não getDatabase()
-                                val repository = ProfileRepository(INSTANCE!!.profilesDao())
-                            }
                         }
                     })
                     .fallbackToDestructiveMigration(true)
@@ -60,7 +56,5 @@ import kotlinx.coroutines.launch
                 instance
             }
         }
-
-
     }
 }

--- a/app/src/main/java/com/example/motounplugged/database/dao/BlockedAppsDao.kt
+++ b/app/src/main/java/com/example/motounplugged/database/dao/BlockedAppsDao.kt
@@ -17,7 +17,7 @@ interface BlockedAppsDao {
     @Query("SELECT * FROM BlockedApps where packageName == :packageName LIMIT 1")
     fun findAppByPackageName(packageName: String): BlockedAppsEntity?
 
-    @Query("SELECT * FROM BlockedApps WHERE profileId = :profileId")
+    @Query("SELECT * FROM BlockedApps WHERE blockedProfileId = :profileId")
     suspend fun getBlockedAppsByProfile(profileId: Int): List<BlockedAppsEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -29,6 +29,6 @@ interface BlockedAppsDao {
     @Delete
     suspend fun delete(blockedApps: BlockedAppsEntity)
 
-    @Query("DELETE FROM BlockedApps WHERE profileId = :profileId")
+    @Query("DELETE FROM BlockedApps WHERE blockedProfileId = :profileId")
     suspend fun deleteAllBlockedAppsFromProfile(profileId: Int)
 }

--- a/app/src/main/java/com/example/motounplugged/database/dao/BlockedAppsDao.kt
+++ b/app/src/main/java/com/example/motounplugged/database/dao/BlockedAppsDao.kt
@@ -14,16 +14,21 @@ interface BlockedAppsDao {
     @Query("SELECT * FROM BlockedApps")
     fun findAll(): Flow<List<BlockedAppsEntity>>
 
-    @Query("SELECT * FROM BlockedApps where uniqueIdApp == :id LIMIT 1")
-    fun findAppbyId(id: Int): BlockedAppsEntity?
+    @Query("SELECT * FROM BlockedApps where packageName == :packageName LIMIT 1")
+    fun findAppByPackageName(packageName: String): BlockedAppsEntity?
+
+    @Query("SELECT * FROM BlockedApps WHERE profileId = :profileId")
+    suspend fun getBlockedAppsByProfile(profileId: Int): List<BlockedAppsEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun save(profiles: BlockedAppsEntity)
+    suspend fun save(blockedApps: BlockedAppsEntity)
 
     @Update
-    suspend fun update(profiles: BlockedAppsEntity)
+    suspend fun update(blockedApps: BlockedAppsEntity)
 
     @Delete
-    suspend fun delete(profiles: BlockedAppsEntity)
+    suspend fun delete(blockedApps: BlockedAppsEntity)
 
+    @Query("DELETE FROM BlockedApps WHERE profileId = :profileId")
+    suspend fun deleteAllBlockedAppsFromProfile(profileId: Int)
 }

--- a/app/src/main/java/com/example/motounplugged/database/dao/ProfilesDao.kt
+++ b/app/src/main/java/com/example/motounplugged/database/dao/ProfilesDao.kt
@@ -5,7 +5,9 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
+import com.example.motounplugged.database.entities.ProfileBlockedApps
 import com.example.motounplugged.database.entities.ProfilesEntity
 import kotlinx.coroutines.flow.Flow
 //import java.util.concurrent.Flow as JavaUtilConcurrentFlow
@@ -17,6 +19,11 @@ interface ProfilesDao {
 
     @Query("SELECT * FROM Profiles WHERE idProfile== :id LIMIT 1")
     suspend fun getProfileById(id: Int): ProfilesEntity?
+
+    @Transaction
+    @Query("SELECT * FROM Profiles WHERE idProfile = :id")
+    suspend fun getProfileWithBlockedApps(id: Int): ProfileBlockedApps?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun save(profiles: ProfilesEntity)
 

--- a/app/src/main/java/com/example/motounplugged/database/entities/BlockedAppsEntity.kt
+++ b/app/src/main/java/com/example/motounplugged/database/entities/BlockedAppsEntity.kt
@@ -1,13 +1,23 @@
 package com.example.motounplugged.database.entities
 
 import androidx.room.Entity
+import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "BlockedApps")
+@Entity(tableName = "BlockedApps",
+        foreignKeys = [
+            ForeignKey(
+                entity = ProfilesEntity::class, // Entidade pai
+                parentColumns = ["idProfile"], // Chave estrangeira
+                childColumns = ["profileId"],  // Chave estrangeira na tabela filha
+                onDelete = ForeignKey.CASCADE  // Deleta os apps quando o perfil é removido
+            )
+        ])
 data class BlockedAppsEntity(
-    @PrimaryKey (autoGenerate = true) val idApp: Int = 0,
+    @PrimaryKey (autoGenerate = true) val idBlockedApp: Int = 0,
     val nameApp: String,
     val categoryApp: String,
-    val uniqueIdApp: Int // Alterar para selecionar o package name correto
+    val packageName: String, // Alterar para selecionar o package name correto
+    val profileId: Int
     ){
 }

--- a/app/src/main/java/com/example/motounplugged/database/entities/BlockedAppsEntity.kt
+++ b/app/src/main/java/com/example/motounplugged/database/entities/BlockedAppsEntity.kt
@@ -9,7 +9,7 @@ import androidx.room.PrimaryKey
             ForeignKey(
                 entity = ProfilesEntity::class, // Entidade pai
                 parentColumns = ["idProfile"], // Chave estrangeira
-                childColumns = ["profileId"],  // Chave estrangeira na tabela filha
+                childColumns = ["blockedProfileId"],  // Chave estrangeira na tabela filha
                 onDelete = ForeignKey.CASCADE  // Deleta os apps quando o perfil é removido
             )
         ])
@@ -18,6 +18,6 @@ data class BlockedAppsEntity(
     val nameApp: String,
     val categoryApp: String,
     val packageName: String, // Alterar para selecionar o package name correto
-    val profileId: Int
+    val blockedProfileId: Int
     ){
 }

--- a/app/src/main/java/com/example/motounplugged/database/entities/ProfileBlockedApps.kt
+++ b/app/src/main/java/com/example/motounplugged/database/entities/ProfileBlockedApps.kt
@@ -1,0 +1,16 @@
+package com.example.motounplugged.database.entities
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+data class ProfileBlockedApps(
+    @Embedded val profile: ProfilesEntity,
+
+    @Relation(
+        parentColumn = "idProfile",
+        entityColumn = "profileId"
+    )
+
+    val blockedApps: List<ProfileBlockedApps>
+
+)

--- a/app/src/main/java/com/example/motounplugged/database/entities/ProfileBlockedApps.kt
+++ b/app/src/main/java/com/example/motounplugged/database/entities/ProfileBlockedApps.kt
@@ -8,9 +8,9 @@ data class ProfileBlockedApps(
 
     @Relation(
         parentColumn = "idProfile",
-        entityColumn = "profileId"
+        entityColumn = "blockedProfileId"
     )
 
-    val blockedApps: List<ProfileBlockedApps>
+    val blockedApps: List<BlockedAppsEntity>
 
 )

--- a/app/src/main/java/com/example/motounplugged/di/KoinModules.kt
+++ b/app/src/main/java/com/example/motounplugged/di/KoinModules.kt
@@ -31,7 +31,7 @@ val databaseModule = module {
 
 // --- Repositórios ---
 val repositoryModule = module {
-    single { ProfileRepository(get()) }
+    single { ProfileRepository(get(), blockedAppsDao = get()) }
     single { SessionsRepository(get()) }
     single { BlockedAppsRepository(get()) }
 }

--- a/app/src/main/java/com/example/motounplugged/repositories/BlockedAppsRepository.kt
+++ b/app/src/main/java/com/example/motounplugged/repositories/BlockedAppsRepository.kt
@@ -8,8 +8,8 @@ class BlockedAppsRepository(
 ) {
     val blockedApps get() = dao.findAll() // puxa a nossa função do query
 
-    suspend fun getBlockedAppById(id: Int): BlockedAppsEntity?{
-        return dao.findAppbyId(id)
+    suspend fun getBlockedAppByPackageName(packageName: String): BlockedAppsEntity?{
+        return dao.findAppByPackageName(packageName)
     }
     //suspend fun pois usamos coroutines (atualizar dados com base em alterações - flow)
     suspend fun save(blockedApp: BlockedAppsEntity){

--- a/app/src/main/java/com/example/motounplugged/repositories/ProfileRepository.kt
+++ b/app/src/main/java/com/example/motounplugged/repositories/ProfileRepository.kt
@@ -40,7 +40,7 @@ class ProfileRepository (
             nameApp = appName,
             packageName = packageName,
             categoryApp = categoryApp,
-            profileId = profileId
+            blockedProfileId = profileId
         )
         blockedAppsDao.save(app)
     }

--- a/app/src/main/java/com/example/motounplugged/repositories/ProfileRepository.kt
+++ b/app/src/main/java/com/example/motounplugged/repositories/ProfileRepository.kt
@@ -1,12 +1,17 @@
 package com.example.motounplugged.repositories
 
+import com.example.motounplugged.database.dao.BlockedAppsDao
 import com.example.motounplugged.database.dao.ProfilesDao
+import com.example.motounplugged.database.entities.BlockedAppsEntity
+import com.example.motounplugged.database.entities.ProfileBlockedApps
 import com.example.motounplugged.database.entities.ProfilesEntity
 import kotlinx.coroutines.flow.Flow
 
 //repository vai salvar meus dados da DAO
 class ProfileRepository (
-    private val dao: ProfilesDao //utilizar o banco de dados
+    private val dao: ProfilesDao, //utilizar o banco de dados
+    private val blockedAppsDao: BlockedAppsDao
+
 ){
     val profiles get() = dao.findAll() // puxa a nossa função do query
 
@@ -24,6 +29,20 @@ class ProfileRepository (
 
     suspend fun delete(profiles:ProfilesEntity){
         dao.delete(profiles)
+    }
+    // Retorna Profile com os apps bloqueados
+    suspend fun getProfileWithApps(id: Int): ProfileBlockedApps? {
+        return dao.getProfileWithBlockedApps(id)
+    }
+    // Adiciona app bloqueado ao profile selecionado
+    suspend fun addBlockedApp(profileId: Int, appName: String, categoryApp: String, packageName: String) {
+        val app = BlockedAppsEntity(
+            nameApp = appName,
+            packageName = packageName,
+            categoryApp = categoryApp,
+            profileId = profileId
+        )
+        blockedAppsDao.save(app)
     }
 
 }


### PR DESCRIPTION
### Descrição
Este PR adiciona as entidades `BlockedAppsEntity` e `ProfileBlockedAppsEntity`, incluindo:
- Criação da entidade `BlockedAppsEntity`
- Criação da entidade intermediária `ProfileBlockedAppsEntity`
- Atualização do `MotoUnpluggedDataBase` com as novas entidades
- Ajustes nos repositórios para integração entre perfis e aplicativos bloqueados

### Migrações
- Atualização da versão do banco para `version = 3`
- `fallbackToDestructiveMigration(true)` temporariamente habilitado

### Próximos passos
- Implementar queries relacionais (`@Relation`) entre Profiles e BlockedApps
- Adicionar camada de UI para edição dos apps bloqueados
