### PR TITLE
refactor: Implement LazyColumn and StatCard on StatsScreen

### DIFF
--- a/app/src/main/java/com/example/motounplugged/ui/components/StatCard.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/components/StatCard.kt
@@ -1,0 +1,85 @@
+package com.example.motounplugged.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.motounplugged.ui.features.stats.StatItem
+
+@Composable
+fun StatCard(item: StatItem, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(52.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = item.icon,
+                    contentDescription = item.label,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(28.dp)
+                )
+            }
+
+            Spacer(Modifier.width(16.dp))
+
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = item.label,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant // Cinza sutil
+                )
+
+                Spacer(Modifier.height(4.dp))
+
+                Text(
+                    text = item.value,
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface // Preto/Escuro
+                )
+
+                Text(
+                    text = item.subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant // Cinza sutil
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/motounplugged/ui/features/stats/StatsScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/stats/StatsScreen.kt
@@ -1,73 +1,136 @@
 package com.example.motounplugged.ui.features.stats
 
-import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.gestures.scrollable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontStyle
+
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.example.motounplugged.ui.components.StatCard
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.CheckCircleOutline
+import androidx.compose.material.icons.filled.LocalFireDepartment
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 
+/**
+ * A tela principal de Estatísticas.
+ */
 @Composable
-
 fun StatsScreen(
     modifier: Modifier = Modifier
 ){
-    Column(
+    LazyColumn(
         modifier = modifier
-            .fillMaxSize()
-            .padding(horizontal = 16.dp)
-            .verticalScroll(rememberScrollState())
+            .fillMaxSize(),
+        contentPadding = PaddingValues(vertical = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Column (
-            modifier = Modifier
-                .fillMaxWidth()
-        ){
-            Text(
-                text = "Estatísticas",
-                fontSize = 25.sp,
-                fontStyle = FontStyle.Normal,
-                fontWeight = FontWeight.Bold,
-                color = Color.Black,
+
+        item {
+            Column (
                 modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-            )
-            Text(
-                text = "Monitore seu desempenho de foco",
-                fontSize = 20.sp,
-                fontStyle = FontStyle.Normal,
-                color = Color.Gray,
-                modifier = Modifier
-                    .padding(top = 5.dp)
-                    .align(Alignment.CenterHorizontally)
-            )
+                    .fillMaxWidth()
+
+                    .padding(horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ){
+                Text(
+                    text = "Estatísticas",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = "Monitore seu desempenho de foco",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 5.dp)
+                )
+            }
+            Spacer(Modifier.height(24.dp))
         }
 
-        Column(
-            modifier = Modifier
-                .fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
-        ) {
-            Text(
-                text = "*Tela em desenvolvimento*",
-                fontSize = 15.sp,
-                fontStyle = FontStyle.Normal,
-                color = Color.Gray,
+        items(mockStatsList) { statItem ->
+            StatCard(
+                item = statItem,
                 modifier = Modifier
-                    .padding(top = 250.dp)
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 12.dp)
             )
+        }
+    }
+}
+
+
+data class StatItem(
+    val icon: ImageVector,
+    val label: String,
+    val value: String,
+    val subtitle: String
+)
+
+val mockStatsList = listOf(
+    StatItem(
+        icon = Icons.Default.LocalFireDepartment,
+        label = "Sequência atual",
+        value = "7",
+        subtitle = "dias consecutivos"
+    ),
+    StatItem(
+        icon = Icons.Default.TrendingUp,
+        label = "Melhor sequência",
+        value = "12",
+        subtitle = "dias"
+    ),
+    StatItem(
+        icon = Icons.Default.Schedule,
+        label = "Tempo total recuperado",
+        value = "45h 23min",
+        subtitle = "este mês"
+    ),
+    StatItem(
+        icon = Icons.Default.CheckCircleOutline,
+        label = "Sessões completadas",
+        value = "23",
+        subtitle = "total"
+    ),
+    StatItem(
+        icon = Icons.Default.Shield,
+        label = "Apps bloqueados",
+        value = "156",
+        subtitle = "tentativas"
+    ),
+    StatItem(
+        icon = Icons.Default.CalendarToday,
+        label = "Média diária",
+        value = "3h 15min",
+        subtitle = "tempo de foco"
+    )
+)
+
+@Preview(showBackground = true)
+@Composable
+fun StatisticsScreenPreview() {
+    MaterialTheme {
+        Surface(color = MaterialTheme.colorScheme.background) {
+            StatsScreen()
         }
     }
 }


### PR DESCRIPTION

This PR delivers a significant performance improvement and structural refactoring to the `StatsScreen` by introducing the use of a `LazyColumn` and a new dedicated component for displaying statistics.

---

### Key Changes:

* **Performance Refactoring (LazyColumn):**
    * Replaced the previous scrollable `Column` (using `verticalScroll`) with a highly efficient **`LazyColumn`** on the `StatsScreen`. This ensures that only visible items are rendered, drastically improving performance, especially with a growing list of statistics.
* **New UI Component (`StatCard`):**
    * Created the reusable **`StatCard` Composable** to clearly and consistently represent individual statistics.
* **Data Structure:**
    * Introduced the **`StatItem` data class** to model the statistics data (e.g., streak, focus time, completed sessions), ensuring a clean separation between UI and data logic.
* **Mock Data:**
    * Populated the screen with a mock list of statistics for development and preview purposes.
    * Added a **`@Preview`** function for the new screen layout.

---

This refactoring makes the `StatsScreen` faster, more scalable, and easier to maintain.

<img width="328" height="734" alt="image" src="https://github.com/user-attachments/assets/51782bfb-d8f7-46b4-ba04-cc7474a5068e" />
