### PR TITLE
Feat/create login screen

### DIFF
--- a/app/src/main/java/com/example/motounplugged/MainActivity.kt
+++ b/app/src/main/java/com/example/motounplugged/MainActivity.kt
@@ -1,9 +1,11 @@
 // MainActivity.kt
 package com.example.motounplugged
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.annotation.RequiresApi
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -14,29 +16,29 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
 import com.example.motounplugged.ui.features.register.RegisterScreen
 import com.example.motounplugged.ui.navigation.AppNavHost
+import com.example.motounplugged.ui.navigation.LRNavHost
 import com.example.motounplugged.ui.theme.MotoUnpluggedTheme
 //import androidx.core.splashscreen.installSplashScreen
 
 class MainActivity : ComponentActivity() {
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
         setContent {
             MotoUnpluggedTheme {
-                val navController = rememberNavController()
                 var isLoggedIn by remember { mutableStateOf(false) }
 
                 if (!isLoggedIn) {
-                    RegisterScreen(
-                        onRegisterComplete = {
-                            isLoggedIn = true // sai da tela de cadastro
-                        }
+                    LRNavHost(
+                        onLoginSuccess = { isLoggedIn = true },
+                        onRegisterComplete = { /* voltar pra login */ }
                     )
                 } else {
-                    MotoUnpluggedApp(
-                        onLogout = { isLoggedIn = false}) // retorna para register
+                    MotoUnpluggedApp( // <-- CHAMA SUA APP COM SIDEBAR
+                        onLogout = { isLoggedIn = false }
+                    )
                 }
-
             }
         }
     }

--- a/app/src/main/java/com/example/motounplugged/MainActivity.kt
+++ b/app/src/main/java/com/example/motounplugged/MainActivity.kt
@@ -32,10 +32,10 @@ class MainActivity : ComponentActivity() {
                 if (!isLoggedIn) {
                     LRNavHost(
                         onLoginSuccess = { isLoggedIn = true },
-                        onRegisterComplete = { /* voltar pra login */ }
+                        onRegisterComplete = { /* voltar pra login pois aceita as verificações de não vazio*/ }
                     )
                 } else {
-                    MotoUnpluggedApp( // <-- CHAMA SUA APP COM SIDEBAR
+                    MotoUnpluggedApp( // chama nosso app interno com a sidebar
                         onLogout = { isLoggedIn = false }
                     )
                 }

--- a/app/src/main/java/com/example/motounplugged/MotoUnpluggedApp.kt
+++ b/app/src/main/java/com/example/motounplugged/MotoUnpluggedApp.kt
@@ -1,5 +1,7 @@
 package com.example.motounplugged
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -19,10 +21,12 @@ import kotlinx.coroutines.launch
 
 import com.example.motounplugged.ui.screens.FAB_new_profile
 
+@RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MotoUnpluggedApp(
-    onLogout: () -> Unit) {
+    onLogout: () -> Unit
+    ) {
     Surface(
         modifier = Modifier .fillMaxSize(),
         color = Color.White
@@ -123,6 +127,11 @@ fun MotoUnpluggedApp(
 
         ) { paddingValues ->
             AppNavHost(
+                onLogout = {
+                    navController.navigate("login") {
+                        popUpTo(0)
+                    }
+                },
                 navController = navController,
                 modifier = Modifier.padding(paddingValues)
             )

--- a/app/src/main/java/com/example/motounplugged/di/KoinModules.kt
+++ b/app/src/main/java/com/example/motounplugged/di/KoinModules.kt
@@ -9,6 +9,7 @@ import com.example.motounplugged.repositories.ProfileRepository
 import com.example.motounplugged.repositories.SessionsRepository
 import com.example.motounplugged.repositories.UserRepository
 import com.example.motounplugged.ui.features.createprofile.CreateProfileViewModel
+import com.example.motounplugged.ui.features.login.LoginScreenViewModel
 import com.example.motounplugged.ui.features.profiles.ProfilesScreenViewModel
 import com.example.motounplugged.ui.features.register.RegisterScreenViewModel
 import com.example.motounplugged.ui.features.selectapps.SelectAppsViewModel
@@ -74,6 +75,10 @@ val viewModelModule = module {
     viewModel{
         RegisterScreenViewModel(get())
     }
+    viewModel{
+        LoginScreenViewModel(get())
+    }
+
 
 
 

--- a/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
@@ -218,12 +218,12 @@ fun ClickableTextComponent(value: String, onTextSelected : (String) -> Unit){
     val annotatedString = buildAnnotatedString {
         append(initialText)
         //definir o estilo do meu privacy policy
-        withStyle(style = SpanStyle(color = Primary)){
+        withStyle(style = SpanStyle(color = Color.Gray)){
             pushStringAnnotation(tag = privacyPolicyText, annotation = privacyPolicyText)
             append(privacyPolicyText)
         }
         append(andText)
-        withStyle(style = SpanStyle(color = Primary)){
+        withStyle(style = SpanStyle(color = Color.Gray)){
             pushStringAnnotation(tag = termsAndConditionsText, annotation = termsAndConditionsText)
             append(termsAndConditionsText)
         }
@@ -280,7 +280,7 @@ fun ButtonComponent(value: String,  onClick:() -> Unit){
                 .fillMaxWidth()
                 .heightIn(48.dp)
                 .background(
-                    brush = Brush.horizontalGradient(listOf(Gray20, Primary)),
+                    brush = Brush.horizontalGradient(listOf(Gray20, Color.Gray)),
                     shape = RoundedCornerShape(50.dp)
                 ),
                 contentAlignment = Alignment.Center
@@ -341,7 +341,7 @@ fun ClickableLoginTextComponent(tryingToLogin:Boolean = true,onTextSelected :  (
     val annotatedString = buildAnnotatedString {
         append(initialText)
         //definir o estilo do meu privacy policy
-        withStyle(style = SpanStyle(color = Primary)){
+        withStyle(style = SpanStyle(color = Color.Gray)){
             pushStringAnnotation(tag = LoginText, annotation = LoginText)
             append(LoginText)
         }

--- a/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
@@ -263,8 +264,6 @@ fun UnderLinedTextComponents(value:String){
     )
 }
 
-
-
 //botão de registro e login
 @Composable
 fun ButtonComponent(value: String,  onClick: () -> Unit){
@@ -295,4 +294,71 @@ fun ButtonComponent(value: String,  onClick: () -> Unit){
 
     }
 
+}
+
+//divisor de componentes (-----or-----)
+@Composable
+fun DividerTextComponent(){
+    Row (
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ){
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            color = Color.Gray,
+            thickness = 1.dp
+        )
+
+        Text(
+            modifier = Modifier
+                .padding(8.dp),
+            text = stringResource(id = R.string.or),
+            fontSize = 18.sp,
+            color = Color.DarkGray
+        )
+
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            color = Color.Gray,
+            thickness = 1.dp
+        )
+    }
+}
+
+//componente da string login e register para navegação
+//se for true pertence a tela de register se for false
+//pertence a tela de login
+@Composable
+fun ClickableLoginTextComponent(tryingToLogin:Boolean = true,onTextSelected :  (String) -> Unit){
+    val initialText = if (tryingToLogin) "Already have an account? " else "Don't have an account yet?"
+    val LoginText = if (tryingToLogin) "Login" else "Register"
+
+    //construtor para criar a string de trms e serviços
+    val annotatedString = buildAnnotatedString {
+        append(initialText)
+        //definir o estilo do meu privacy policy
+        withStyle(style = SpanStyle(color = Primary)){
+            pushStringAnnotation(tag = LoginText, annotation = LoginText)
+            append(LoginText)
+        }
+
+    }
+    //offset deslocamento ao clicar do text
+    ClickableText(text = annotatedString, onClick = { offset ->
+        //offset no inicio de fim para verificar se há deslocamento
+        annotatedString.getStringAnnotations(offset,offset)
+            //verifica se houver um clique valido span, also verifica se esta retornando uma string anotada
+            .firstOrNull()?.also { span ->
+                Log.d("ClickableTextComponent", "{${span.item}")
+
+                //verifica se o item esta clicavel e na rota
+                if(span.item == LoginText){
+                    onTextSelected(span.item)
+
+                }
+            }})
 }

--- a/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -242,7 +243,29 @@ fun ClickableTextComponent(value: String, onTextSelected : (String) -> Unit){
     }})
 }
 
-//botão de registro
+//componente de texto sublinhado utilizado na tela de login
+@Composable
+fun UnderLinedTextComponents(value:String){
+    Text(
+        text = value,
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 40.dp),
+        style = TextStyle(
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Normal,
+            fontStyle = FontStyle.Normal
+        ),
+        color = colorResource(id = R.color.colorGray),
+        textAlign = TextAlign.Center,
+        //adiciiona um sublinhado ao texto
+        textDecoration = TextDecoration.Underline
+    )
+}
+
+
+
+//botão de registro e login
 @Composable
 fun ButtonComponent(value: String,  onClick: () -> Unit){
     Button(

--- a/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
@@ -266,7 +266,7 @@ fun UnderLinedTextComponents(value:String){
 
 //botão de registro e login
 @Composable
-fun ButtonComponent(value: String,  onClick: () -> Unit){
+fun ButtonComponent(value: String,  onClick:() -> Unit){
     Button(
         onClick = onClick,
         modifier = Modifier

--- a/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
@@ -334,8 +334,8 @@ fun DividerTextComponent(){
 //pertence a tela de login
 @Composable
 fun ClickableLoginTextComponent(tryingToLogin:Boolean = true,onTextSelected :  (String) -> Unit){
-    val initialText = if (tryingToLogin) "Already have an account? " else "Don't have an account yet?"
-    val LoginText = if (tryingToLogin) "Login" else "Register"
+    val initialText = if (tryingToLogin) "                      Already have an account? " else "                      Don't have an account yet?"
+    val LoginText = if (tryingToLogin) " Login" else " Register"
 
     //construtor para criar a string de trms e serviços
     val annotatedString = buildAnnotatedString {

--- a/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreen.kt
@@ -1,7 +1,8 @@
 package com.example.motounplugged.ui.features.login
 
+import android.os.Build
 import android.widget.Toast
-import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.DefaultTab.AlbumsTab.value
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -16,7 +17,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -24,16 +24,24 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.motounplugged.R
 import com.example.motounplugged.ui.components.ButtonComponent
+import com.example.motounplugged.ui.components.ClickableLoginTextComponent
+import com.example.motounplugged.ui.components.DividerTextComponent
 import com.example.motounplugged.ui.components.MyTextField
 import com.example.motounplugged.ui.components.NormalTextComponents
 import com.example.motounplugged.ui.components.PasswordTextField
 import com.example.motounplugged.ui.components.TitleTextComponents
 import com.example.motounplugged.ui.components.UnderLinedTextComponents
+import com.example.motounplugged.ui.features.register.RegisterScreen
+import com.example.motounplugged.ui.navigation.AppNavHost
 import com.example.motounplugged.ui.theme.MotoUnpluggedTheme
 
 //SHA criptografia
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun LoginScreen(){
+fun LoginScreen(
+    onLoginSuccess: () -> Unit,
+    onNavigateToRegister: () -> Unit
+){
     val context = LocalContext.current
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -82,17 +90,15 @@ fun LoginScreen(){
                     } else {
                         //COLOCAR AS COFIGURAÇÕES DA VIEWMODEL DA LOGIN REGISTER QUE
                         //VAI RECEBER O BANCO DE DADOS DA TABELA DE REGISTRO
-
-                       // viewModel.registerUser(firstName, lastName, email, password)
-                        //Toast.makeText(
-                          //  context,
-                            //"Usuário cadastrado com sucesso!",
-                            //Toast.LENGTH_SHORT
-                       // ).show()
-                        //onregistercomplete esta na main e serve para verificar se a os campos não estão vazios
-                        //onRegisterComplete()
+                        onLoginSuccess()
                     }
-                })
+                }
+            )
+            Spacer(modifier = Modifier.height(25.dp))
+            DividerTextComponent()
+            ClickableLoginTextComponent(tryingToLogin = false, onTextSelected = {
+                onNavigateToRegister()
+            })
 
         }
 
@@ -100,10 +106,11 @@ fun LoginScreen(){
 
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Preview
 @Composable
 fun LoginScreenPreview(){
     MotoUnpluggedTheme {
-        LoginScreen()
+        LoginScreen(onLoginSuccess = {},onNavigateToRegister = {})
     }
 }

--- a/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreen.kt
@@ -65,6 +65,7 @@ fun LoginScreen(
             modifier = Modifier
                 .fillMaxSize()
         ) {
+            Spacer(modifier = Modifier.height(50.dp))
             NormalTextComponents(value = stringResource(id = R.string.login))
             TitleTextComponents(value = stringResource(id = R.string.welcome))
             Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreen.kt
@@ -11,9 +11,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -34,14 +36,19 @@ import com.example.motounplugged.ui.components.UnderLinedTextComponents
 import com.example.motounplugged.ui.features.register.RegisterScreen
 import com.example.motounplugged.ui.navigation.AppNavHost
 import com.example.motounplugged.ui.theme.MotoUnpluggedTheme
+import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
 
 //SHA criptografia
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun LoginScreen(
     onLoginSuccess: () -> Unit,
-    onNavigateToRegister: () -> Unit
+    onNavigateToRegister: () -> Unit,
+
 ){
+    val viewModel: LoginScreenViewModel = koinViewModel()
+    val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -90,7 +97,16 @@ fun LoginScreen(
                     } else {
                         //COLOCAR AS COFIGURAÇÕES DA VIEWMODEL DA LOGIN REGISTER QUE
                         //VAI RECEBER O BANCO DE DADOS DA TABELA DE REGISTRO
-                        onLoginSuccess()
+                        coroutineScope.launch {
+                            val isValid = viewModel.login(email,password)
+                            if (isValid){
+                                onLoginSuccess()
+                            } else{
+                                Toast.makeText(context, "Email ou senha incorretos", Toast.LENGTH_SHORT).show()
+                            }
+
+                        }
+
                     }
                 }
             )

--- a/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreen.kt
@@ -1,18 +1,43 @@
 package com.example.motounplugged.ui.features.login
 
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.DefaultTab.AlbumsTab.value
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.motounplugged.R
+import com.example.motounplugged.ui.components.ButtonComponent
+import com.example.motounplugged.ui.components.MyTextField
+import com.example.motounplugged.ui.components.NormalTextComponents
+import com.example.motounplugged.ui.components.PasswordTextField
+import com.example.motounplugged.ui.components.TitleTextComponents
+import com.example.motounplugged.ui.components.UnderLinedTextComponents
 import com.example.motounplugged.ui.theme.MotoUnpluggedTheme
 
+//SHA criptografia
 @Composable
 fun LoginScreen(){
+    val context = LocalContext.current
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
     Surface(
         color = Color.White,
         modifier = Modifier
@@ -21,6 +46,55 @@ fun LoginScreen(){
             .padding(28.dp)
             .padding(top = 50.dp)
     ){
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+        ) {
+            NormalTextComponents(value = stringResource(id = R.string.login))
+            TitleTextComponents(value = stringResource(id = R.string.welcome))
+            Spacer(modifier = Modifier.height(20.dp))
+
+            MyTextField(
+                labelValue = stringResource(id = R.string.email),
+                painterResource(id = R.drawable.email),
+                value = email,
+                onValueChange = {email = it})
+
+            PasswordTextField(
+                labelValue = stringResource(id = R.string.password),
+                painterResource = painterResource(id = R.drawable.password),
+                value = password,
+                onValueChange = {password = it}
+            )
+
+            Spacer(modifier = Modifier.height(30.dp))
+            UnderLinedTextComponents(value = stringResource(id = R.string.forgot_password))
+
+            Spacer(modifier = Modifier.height(100.dp))
+            ButtonComponent(value = stringResource(id = R.string.login),
+                onClick = {
+                    if (email.isBlank() || password.isBlank()) {
+                        Toast.makeText(
+                            context,
+                            "Por favor, preencha todos os campos!",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    } else {
+                        //COLOCAR AS COFIGURAÇÕES DA VIEWMODEL DA LOGIN REGISTER QUE
+                        //VAI RECEBER O BANCO DE DADOS DA TABELA DE REGISTRO
+
+                       // viewModel.registerUser(firstName, lastName, email, password)
+                        //Toast.makeText(
+                          //  context,
+                            //"Usuário cadastrado com sucesso!",
+                            //Toast.LENGTH_SHORT
+                       // ).show()
+                        //onregistercomplete esta na main e serve para verificar se a os campos não estão vazios
+                        //onRegisterComplete()
+                    }
+                })
+
+        }
 
     }
 

--- a/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreen.kt
@@ -1,0 +1,35 @@
+package com.example.motounplugged.ui.features.login
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.motounplugged.ui.theme.MotoUnpluggedTheme
+
+@Composable
+fun LoginScreen(){
+    Surface(
+        color = Color.White,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Color.White)
+            .padding(28.dp)
+            .padding(top = 50.dp)
+    ){
+
+    }
+
+}
+
+@Preview
+@Composable
+fun LoginScreenPreview(){
+    MotoUnpluggedTheme {
+        LoginScreen()
+    }
+}

--- a/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreenViewModel.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/login/LoginScreenViewModel.kt
@@ -1,0 +1,15 @@
+package com.example.motounplugged.ui.features.login
+
+import androidx.lifecycle.ViewModel
+import com.example.motounplugged.repositories.UserRepository
+
+class LoginScreenViewModel(
+    private val repository: UserRepository
+):ViewModel() {
+
+    suspend fun login(email:String,password: String):Boolean{
+        val user = repository.getUser(email)
+        return user != null && user.password == password
+    }
+
+}

--- a/app/src/main/java/com/example/motounplugged/ui/features/register/RegisterScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/register/RegisterScreen.kt
@@ -113,6 +113,7 @@ fun RegisterScreen(
                             "Usuário cadastrado com sucesso!",
                             Toast.LENGTH_SHORT
                         ).show()
+                        //onregistercomplete esta na main e serve para verificar se a os campos não estão vazios
                         onRegisterComplete()
                     }
                 })

--- a/app/src/main/java/com/example/motounplugged/ui/features/register/RegisterScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/register/RegisterScreen.kt
@@ -30,7 +30,6 @@ import com.example.motounplugged.ui.components.MyTextField
 import com.example.motounplugged.ui.components.NormalTextComponents
 import com.example.motounplugged.ui.components.PasswordTextField
 import com.example.motounplugged.ui.components.TitleTextComponents
-import com.example.motounplugged.ui.navigation.AppScreens
 import com.example.motounplugged.ui.theme.MotoUnpluggedTheme
 import org.koin.androidx.compose.koinViewModel
 
@@ -39,6 +38,7 @@ import org.koin.androidx.compose.koinViewModel
 fun RegisterScreen(
     onRegisterComplete: () -> Unit,
     onBackToLogin: () -> Unit,
+    onNavigateToTermsAndConditions: () -> Unit,
     viewModel: RegisterScreenViewModel = koinViewModel()
 ){
     val context = LocalContext.current
@@ -96,7 +96,7 @@ fun RegisterScreen(
 
             CheckboxComponent(value = stringResource(id = R.string.terms_and_conditions),
                 onTextSelected = {
-                    AppScreens.TermsAndConditionsScreen.route
+                    onNavigateToTermsAndConditions()
                 })
 
             Spacer(modifier = Modifier.height(100.dp))
@@ -140,6 +140,6 @@ fun RegisterScreen(
 @Composable
 fun registerscreen(){
     MotoUnpluggedTheme {
-        RegisterScreen(onRegisterComplete = {}, onBackToLogin = {})
+        RegisterScreen(onRegisterComplete = {}, onBackToLogin = {},onNavigateToTermsAndConditions={})
     }
 }

--- a/app/src/main/java/com/example/motounplugged/ui/features/register/RegisterScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/register/RegisterScreen.kt
@@ -24,6 +24,8 @@ import com.example.motounplugged.R
 import com.example.motounplugged.R.string.hello
 import com.example.motounplugged.ui.components.ButtonComponent
 import com.example.motounplugged.ui.components.CheckboxComponent
+import com.example.motounplugged.ui.components.ClickableLoginTextComponent
+import com.example.motounplugged.ui.components.DividerTextComponent
 import com.example.motounplugged.ui.components.MyTextField
 import com.example.motounplugged.ui.components.NormalTextComponents
 import com.example.motounplugged.ui.components.PasswordTextField
@@ -36,6 +38,7 @@ import org.koin.androidx.compose.koinViewModel
 @Composable
 fun RegisterScreen(
     onRegisterComplete: () -> Unit,
+    onBackToLogin: () -> Unit,
     viewModel: RegisterScreenViewModel = koinViewModel()
 ){
     val context = LocalContext.current
@@ -117,6 +120,11 @@ fun RegisterScreen(
                         onRegisterComplete()
                     }
                 })
+            Spacer(modifier = Modifier.height(25.dp))
+            DividerTextComponent()
+            ClickableLoginTextComponent(tryingToLogin = true, onTextSelected = {
+                onBackToLogin()
+            })
 
 
 
@@ -132,6 +140,6 @@ fun RegisterScreen(
 @Composable
 fun registerscreen(){
     MotoUnpluggedTheme {
-        RegisterScreen(onRegisterComplete = {})
+        RegisterScreen(onRegisterComplete = {}, onBackToLogin = {})
     }
 }

--- a/app/src/main/java/com/example/motounplugged/ui/features/terms_and_conditions/TermsAndConditionsScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/terms_and_conditions/TermsAndConditionsScreen.kt
@@ -14,7 +14,9 @@ import com.example.motounplugged.ui.components.TitleTextComponents
 import com.example.motounplugged.R
 
 @Composable
-fun TermsAndConditionsScreen(){
+fun TermsAndConditionsScreen(
+    onNavigateToTermsAndConditions: () -> Unit
+){
     Surface(
         modifier = Modifier
             .fillMaxSize()
@@ -29,5 +31,5 @@ fun TermsAndConditionsScreen(){
 @Preview
 @Composable
 fun TermsAndConditionsScreenPreview(){
-    TermsAndConditionsScreen()
+    TermsAndConditionsScreen(onNavigateToTermsAndConditions={})
 }

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/AppNavHost.kt
@@ -17,6 +17,7 @@ import com.example.motounplugged.ui.screens.ScheduleScreen
 import com.example.motounplugged.ui.features.createprofile.CreateProfileScreen
 import com.example.motounplugged.ui.features.createprofile.CreateProfileViewModel
 import com.example.motounplugged.ui.features.home.HomeScreen
+import com.example.motounplugged.ui.features.login.LoginScreen
 import com.example.motounplugged.ui.features.profiles.ProfilesScreenViewModel
 import com.example.motounplugged.ui.features.register.RegisterScreen
 import com.example.motounplugged.ui.features.settings.SettingsScreen
@@ -33,6 +34,7 @@ import org.koin.androidx.compose.koinViewModel
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun AppNavHost(
+    onLogout: () -> Unit,
     navController: NavHostController,
     modifier: Modifier = Modifier
 ) {
@@ -83,12 +85,6 @@ fun AppNavHost(
             CreateProfileScreen(navController, profileId)
         }
 
-        composable( AppScreens.Register.route){
-            RegisterScreen(onRegisterComplete = {})
-        }
-        composable(AppScreens.TermsAndConditionsScreen.route){
-            TermsAndConditionsScreen()
-        }
         composable(AppScreens.SelectApps.route) {
             SelectAppsScreen(navController = navController)
         }

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/AppScreens.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/AppScreens.kt
@@ -12,6 +12,7 @@ sealed class AppScreens(val route: String) {
     object CreateProfile : AppScreens("create_profile")
     object SelectApps : AppScreens("select_apps")
     object Register : AppScreens("register")
+    object Login : AppScreens("login")
     object TermsAndConditionsScreen : AppScreens("terms_and_conditions")
     object SplashScreen: AppScreens("splash")
 }

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/LRNavHost.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/LRNavHost.kt
@@ -1,0 +1,46 @@
+package com.example.motounplugged.ui.navigation
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.motounplugged.ui.features.login.LoginScreen
+import com.example.motounplugged.ui.features.register.RegisterScreen
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun LRNavHost(
+    onLoginSuccess: () -> Unit,
+    onRegisterComplete: () -> Unit
+) {
+    val navController = rememberNavController()
+
+    NavHost(
+        navController = navController,
+        startDestination = AppScreens.Login.route
+    ) {
+        composable(AppScreens.Login.route) {
+            LoginScreen(
+                onNavigateToRegister = {
+                    navController.navigate(AppScreens.Register.route)
+                },
+                onLoginSuccess = {
+                    onLoginSuccess()
+                }
+            )
+        }
+
+        composable(AppScreens.Register.route) {
+            RegisterScreen(
+                onRegisterComplete = {
+                    navController.popBackStack() // volta pra login
+                },
+                onBackToLogin = {
+                    navController.popBackStack()
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/LRNavHost.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/LRNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.example.motounplugged.ui.features.login.LoginScreen
 import com.example.motounplugged.ui.features.register.RegisterScreen
+import com.example.motounplugged.ui.features.terms_and_conditions.TermsAndConditionsScreen
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -39,6 +40,17 @@ fun LRNavHost(
                 },
                 onBackToLogin = {
                     navController.popBackStack()
+                },
+                onNavigateToTermsAndConditions = {
+                    navController.navigate(AppScreens.TermsAndConditionsScreen.route)
+                }
+            )
+        }
+
+        composable(AppScreens.TermsAndConditionsScreen.route){
+            TermsAndConditionsScreen(
+                onNavigateToTermsAndConditions = {
+                    navController.navigate(AppScreens.TermsAndConditionsScreen.route)
                 }
             )
         }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,4 +10,5 @@
     <color name = "green_lite">#C3D48B</color>
     <color name = "red">#B20027</color>
     <color name="colorText">#1D1617</color>
+    <color name="colorGray">#7B6F72</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,5 +12,8 @@
     <string name="terms_and_conditions">By continuing you accept our Privacy Policy and Term of Use</string>
     <string name="terms_and_conditions_header">Terms of Use</string>
     <string name="register">Register</string>
+    <string name="login">Login</string>
+    <string name="go_to_login">Already have an account? Login</string>
+    <string name="forgot_password">Forgot your password</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
     <string name="register">Register</string>
     <string name="login">Login</string>
     <string name="go_to_login">Already have an account? Login</string>
-    <string name="forgot_password">Forgot your password</string>
+    <string name="forgot_password">Forgot your password?</string>
     <string name="or">or</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,5 +15,6 @@
     <string name="login">Login</string>
     <string name="go_to_login">Already have an account? Login</string>
     <string name="forgot_password">Forgot your password</string>
+    <string name="or">or</string>
 
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.1"
+agp = "8.9.0"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.0"
+agp = "8.10.1"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"


### PR DESCRIPTION
## Pull Request: Implement Login Flow, UI Redesign and Terms Navigation

This PR introduces the full implementation of the login flow, including UI redesign, navigation improvements, and communication with the registration module.
It also adds support for navigating from the Register screen to the Terms & Conditions screen.

The Login screen was fully rebuilt from scratch using a clean UI structure, improved component organization, and new callback-based navigation handling.

## Changes
Login System & UI

- feat: Rebuilt the entire LoginScreen from zero using a modern and clean UI structure.

- feat: Added new text fields, password inputs, dividers, and improved layout spacing.

- feat: Updated login button logic to support validation and upcoming ViewModel authentication.

- feat: Connected navigation actions (onLoginSuccess, onNavigateToRegister) to external flow.

## Navigation Improvements

- feat: Added onNavigateToTermsAndConditions() callback in RegisterScreen.

- feat: Implemented navigation logic to open the Terms & Conditions screen directly from the Register flow.

- feat: Improved LRNavHost to correctly separate authentication routes from internal app navigation.

- refactor: Updated login/register flows to be outside the sidebar navigation structure.

## Terms & Conditions

- feat: Added navigation support from Register → TermsAndConditionsScreen.

- feat: Ensured correct routing inside the global navigation graph.

## Checklist

 - Recreated LoginScreen with updated UI and components.

 - Added navigation callback for Terms & Conditions.

 - Updated LRNavHost to properly handle login → app transition.

 - Ensured Register navigation returns correctly to Login.

-  Improved overall navigation structure to isolate authentication flow.
