### PR TITLE
Feat/terms and conditions screen

### DIFF
--- a/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
@@ -362,3 +362,23 @@ fun ClickableLoginTextComponent(tryingToLogin:Boolean = true,onTextSelected :  (
                 }
             }})
 }
+
+//componente de texto
+@Composable
+fun TextComponent(value:String){
+    Text(
+        text = value,
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 40.dp),
+        style = TextStyle(
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Normal,
+            fontStyle = FontStyle.Normal
+        ),
+        color = colorResource(id = R.color.colorGray),
+        textAlign = TextAlign.Justify,
+        //adiciiona um sublinhado ao texto
+        //textDecoration = TextDecoration.Underline
+    )
+}

--- a/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/components/AppComponents.kt
@@ -187,7 +187,7 @@ fun PasswordTextField(labelValue: String, painterResource: Painter, value: Strin
 
 //componente de checklist do termos e serviços
 @Composable
-fun CheckboxComponent(value: String, onTextSelected : (String) -> Unit){
+fun CheckboxComponent(value: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit, onTextSelected : (String) -> Unit){
     Row (
         modifier = Modifier
             .fillMaxWidth()
@@ -197,10 +197,10 @@ fun CheckboxComponent(value: String, onTextSelected : (String) -> Unit){
         val checkedState = remember {
             mutableStateOf<Boolean>(false)
         }
-        Checkbox(checked = checkedState.value,
-            onCheckedChange = { it
-                checkedState.value = !checkedState.value
-            })
+        Checkbox(
+            checked = checked,
+            onCheckedChange = { onCheckedChange(it)}
+        )
         ClickableTextComponent(value = value, onTextSelected)
 
     }

--- a/app/src/main/java/com/example/motounplugged/ui/features/register/RegisterScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/register/RegisterScreen.kt
@@ -42,10 +42,6 @@ fun RegisterScreen(
     viewModel: RegisterScreenViewModel = koinViewModel()
 ){
     val context = LocalContext.current
-    var firstName by remember { mutableStateOf("") }
-    var lastName by remember { mutableStateOf("") }
-    var email by remember { mutableStateOf("") }
-    var password by remember { mutableStateOf("") }
 
     Surface(
         color = Color.White,
@@ -69,32 +65,35 @@ fun RegisterScreen(
             MyTextField(
                 labelValue = stringResource(id = R.string.first_name),
                 painterResource(id = R.drawable.person_register),
-                value = firstName,
-                onValueChange = {firstName = it}
+                value = viewModel.firstName,
+                onValueChange = {viewModel.firstName = it}
             )
 
             MyTextField(
                 labelValue = stringResource(id = R.string.last_name),
                 painterResource = painterResource(id = R.drawable.person_register),
-                value = lastName,
-                onValueChange = {lastName = it}
+                value = viewModel.lastName,
+                onValueChange = {viewModel.lastName = it}
             )
 
             MyTextField(
                 labelValue = stringResource(id = R.string.email),
                 painterResource = painterResource(id = R.drawable.email),
-                value = email,
-                onValueChange = {email = it}
+                value = viewModel.email,
+                onValueChange = {viewModel.email = it}
             )
 
             PasswordTextField(
                 labelValue = stringResource(id = R.string.password),
                 painterResource = painterResource(id = R.drawable.password),
-                value = password,
-                onValueChange = {password = it}
+                value = viewModel.password,
+                onValueChange = {viewModel.password = it}
             )
 
-            CheckboxComponent(value = stringResource(id = R.string.terms_and_conditions),
+            CheckboxComponent(
+                value = stringResource(id = R.string.terms_and_conditions),
+                checked = viewModel.checkedState,
+                onCheckedChange = {viewModel.checkedState = it},
                 onTextSelected = {
                     onNavigateToTermsAndConditions()
                 })
@@ -103,14 +102,20 @@ fun RegisterScreen(
 
             ButtonComponent(value = stringResource(id = R.string.register),
                 onClick = {
-                    if (firstName.isBlank() || lastName.isBlank() || email.isBlank() || password.isBlank()) {
+                    if (viewModel.firstName.isBlank() || viewModel.lastName.isBlank() || viewModel.email.isBlank() || viewModel.password.isBlank()) {
                         Toast.makeText(
                             context,
                             "Por favor, preencha todos os campos!",
                             Toast.LENGTH_SHORT
                         ).show()
-                    } else {
-                        viewModel.registerUser(firstName, lastName, email, password)
+                    } else if (!viewModel.checkedState){
+                        Toast.makeText(
+                                context,
+                                "Vocẽ deve aceitar os Termos de Serviços e Políticas de Privacidade",
+                                Toast.LENGTH_SHORT
+                                ).show()
+                    }else {
+                        viewModel.registerUser(viewModel.firstName, viewModel.lastName, viewModel.email, viewModel.password)
                         Toast.makeText(
                             context,
                             "Usuário cadastrado com sucesso!",

--- a/app/src/main/java/com/example/motounplugged/ui/features/register/RegisterScreenViewModel.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/register/RegisterScreenViewModel.kt
@@ -1,5 +1,8 @@
 package com.example.motounplugged.ui.features.register
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.motounplugged.repositories.UserRepository
@@ -7,9 +10,17 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+
 class RegisterScreenViewModel(
     private val userRepository: UserRepository
 ): ViewModel() {
+
+    //os dados que tem que ser mantidas ao navegar para os termos e condições
+    var firstName by mutableStateOf("")
+    var lastName by mutableStateOf("")
+    var email by mutableStateOf("")
+    var password by mutableStateOf("")
+    var checkedState by mutableStateOf(false)
 
     private val _state = MutableStateFlow("")
     val state = _state.asStateFlow()

--- a/app/src/main/java/com/example/motounplugged/ui/features/terms_and_conditions/TermsAndConditionsScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/terms_and_conditions/TermsAndConditionsScreen.kt
@@ -1,8 +1,13 @@
 package com.example.motounplugged.ui.features.terms_and_conditions
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -12,6 +17,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.motounplugged.ui.components.TitleTextComponents
 import com.example.motounplugged.R
+import com.example.motounplugged.ui.components.NormalTextComponents
+import com.example.motounplugged.ui.components.TextComponent
 
 @Composable
 fun TermsAndConditionsScreen(
@@ -23,7 +30,24 @@ fun TermsAndConditionsScreen(
             .background(color = Color.White)
             .padding(16.dp)
     ) {
-        TitleTextComponents(value = stringResource(id = R.string.terms_and_conditions_header))
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .background(color = Color.White)
+        ) {
+            Spacer(modifier = Modifier.height(50.dp))
+            TitleTextComponents(value = stringResource(id = R.string.terms_and_conditions_header))
+            Spacer(modifier = Modifier.height(40.dp))
+            NormalTextComponents(value = stringResource(id = R.string.Privacy_Policy))
+            Spacer(modifier = Modifier.height(10.dp))
+            TextComponent(value = stringResource(id = R.string.Privacy_Policy_Text))
+            Spacer(modifier = Modifier.height(20.dp))
+            NormalTextComponents(value = stringResource(id = R.string.Terms_of_use))
+            Spacer(modifier = Modifier.height(10.dp))
+            TextComponent(value = stringResource(id = R.string.Terms_of_use_text))
+
+        }
 
     }
 }

--- a/app/src/main/java/com/example/motounplugged/ui/features/terms_and_conditions/TermsAndConditionsScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/terms_and_conditions/TermsAndConditionsScreen.kt
@@ -1,32 +1,44 @@
 package com.example.motounplugged.ui.features.terms_and_conditions
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.example.motounplugged.ui.components.TitleTextComponents
 import com.example.motounplugged.R
 import com.example.motounplugged.ui.components.NormalTextComponents
 import com.example.motounplugged.ui.components.TextComponent
+import com.example.motounplugged.ui.theme.Gray20
 
 @Composable
 fun TermsAndConditionsScreen(
     onNavigateToTermsAndConditions: () -> Unit,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onClick: () -> Unit
 ){
     Surface(
         modifier = Modifier
@@ -50,26 +62,43 @@ fun TermsAndConditionsScreen(
             NormalTextComponents(value = stringResource(id = R.string.Terms_of_use))
             Spacer(modifier = Modifier.height(10.dp))
             TextComponent(value = stringResource(id = R.string.Terms_of_use_text))
+            Spacer(modifier = Modifier.height(20.dp))
 
-            Button(
-                modifier = Modifier
-                    .background(color = Color.Gray)
-                ,
-                onClick = { onBack() }
-            ) {
-                Text(
-                    "Voltar",
-                color = Color.White)
-
-            }
-
+            Button(onClick = { onBack() },
+                        modifier = Modifier
+                        .fillMaxWidth()
+                    .heightIn(48.dp),
+                contentPadding = PaddingValues(),
+                colors = ButtonDefaults.buttonColors(Color.Transparent))
+            {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(48.dp)
+                        .background(
+                            brush = Brush.horizontalGradient(listOf(Gray20, Color.Gray)),
+                            shape = RoundedCornerShape(50.dp)
+                        ),
+                    contentAlignment = Alignment.Center
+                ){
+                    Text(
+                        text = "Voltar",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
         }
 
     }
+}
 }
 
 @Preview
 @Composable
 fun TermsAndConditionsScreenPreview(){
-    TermsAndConditionsScreen(onNavigateToTermsAndConditions={}, onBack = {})
+    TermsAndConditionsScreen(
+        onNavigateToTermsAndConditions={},
+        onBack = {},
+        onClick = {}
+    )
 }

--- a/app/src/main/java/com/example/motounplugged/ui/features/terms_and_conditions/TermsAndConditionsScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/terms_and_conditions/TermsAndConditionsScreen.kt
@@ -8,11 +8,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.motounplugged.ui.components.TitleTextComponents
@@ -22,7 +25,8 @@ import com.example.motounplugged.ui.components.TextComponent
 
 @Composable
 fun TermsAndConditionsScreen(
-    onNavigateToTermsAndConditions: () -> Unit
+    onNavigateToTermsAndConditions: () -> Unit,
+    onBack: () -> Unit
 ){
     Surface(
         modifier = Modifier
@@ -47,6 +51,18 @@ fun TermsAndConditionsScreen(
             Spacer(modifier = Modifier.height(10.dp))
             TextComponent(value = stringResource(id = R.string.Terms_of_use_text))
 
+            Button(
+                modifier = Modifier
+                    .background(color = Color.Gray)
+                ,
+                onClick = { onBack() }
+            ) {
+                Text(
+                    "Voltar",
+                color = Color.White)
+
+            }
+
         }
 
     }
@@ -55,5 +71,5 @@ fun TermsAndConditionsScreen(
 @Preview
 @Composable
 fun TermsAndConditionsScreenPreview(){
-    TermsAndConditionsScreen(onNavigateToTermsAndConditions={})
+    TermsAndConditionsScreen(onNavigateToTermsAndConditions={}, onBack = {})
 }

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/LRNavHost.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/LRNavHost.kt
@@ -50,7 +50,8 @@ fun LRNavHost(
         composable(AppScreens.TermsAndConditionsScreen.route){
             TermsAndConditionsScreen(
                 onBack = {navController.popBackStack()},
-                onNavigateToTermsAndConditions = {navController.navigate(AppScreens.TermsAndConditionsScreen.route)}
+                onNavigateToTermsAndConditions = {navController.navigate(AppScreens.TermsAndConditionsScreen.route)},
+                onClick = {}
             )
         }
     }

--- a/app/src/main/java/com/example/motounplugged/ui/navigation/LRNavHost.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/navigation/LRNavHost.kt
@@ -49,9 +49,8 @@ fun LRNavHost(
 
         composable(AppScreens.TermsAndConditionsScreen.route){
             TermsAndConditionsScreen(
-                onNavigateToTermsAndConditions = {
-                    navController.navigate(AppScreens.TermsAndConditionsScreen.route)
-                }
+                onBack = {navController.popBackStack()},
+                onNavigateToTermsAndConditions = {navController.navigate(AppScreens.TermsAndConditionsScreen.route)}
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,11 +10,47 @@
     <string name="hide_password">hide password</string>
     <string name="show_password">show password</string>
     <string name="terms_and_conditions">By continuing you accept our Privacy Policy and Term of Use</string>
-    <string name="terms_and_conditions_header">Terms of Use</string>
+    <string name="terms_and_conditions_header">Termos &amp; Condições</string>
     <string name="register">Register</string>
     <string name="login">Login</string>
     <string name="go_to_login">Already have an account? Login</string>
     <string name="forgot_password">Forgot your password?</string>
     <string name="or">or</string>
+    <string name="Privacy_Policy">Política de Privacidade</string>
+    <string name="Privacy_Policy_Text">
+        A sua privacidade é importante para nós. É política do Moto Unplugged 2.0 respeitar a sua privacidade em relação a qualquer informação sua que possamos coletar no Aplicativo Moto Unplugged 2.0, e outros sites que possuímos e operamos. Solicitamos informações pessoais apenas quando realmente precisamos delas para lhe fornecer um serviço. Fazemo-lo por meios justos e legais, com o seu conhecimento e consentimento. Também informamos por que estamos coletando e como será usado. Apenas retemos as informações coletadas pelo tempo necessário para fornecer o serviço solicitado. Quando armazenamos dados, os protegemos dentro de meios comercialmente aceitáveis ​​para evitar perdas e roubos, bem como acesso, divulgação, cópia, uso ou modificação não autorizados. Não compartilhamos informações de identificação pessoal publicamente ou com terceiros, exceto quando exigido por lei.O nosso aplicativo pode ter links para sites externos que não são operados por nós. Esteja ciente de que não temos controle sobre o conteúdo e práticas desses sites e não podemos aceitar responsabilidade por suas respectivas políticas de privacidade.Você é livre para recusar a nossa solicitação de informações pessoais, entendendo que talvez não possamos fornecer alguns dos serviços desejados. O uso continuado de nosso aplicativo será considerado como aceitação de nossas práticas em torno de privacidade e informações pessoais. Se você tiver alguma dúvida sobre como lidamos com dados do usuário e informações pessoais, entre em contacto conosco. Compromisso do Usuário: O usuário se compromete a fazer uso adequado dos conteúdos e da informação que o Moto Unplugged 2.0 oferece no site e com caráter enunciativo, mas não limitativo:
+A) Não se envolver em atividades que sejam ilegais ou contrárias à boa fé a à ordem pública;
+B) Não difundir propaganda ou conteúdo de natureza racista, xenofóbica, jogos de sorte ou azar, qualquer tipo de pornografia ilegal, de apologia ao terrorismo ou contra os direitos humanos;
+C) Não causar danos aos sistemas físicos (hardwares) e lógicos (softwares) do Moto Unplugged 2.0, de seus fornecedores ou terceiros, para introduzir ou disseminar vírus informáticos ou quaisquer outros sistemas de hardware ou software que sejam capazes de causar danos anteriormente mencionados.
+Mais informações: Esperemos que esteja esclarecido e, como mencionado anteriormente, se houver algo que você não tem certeza se precisa ou não, geralmente é mais seguro deixar os cookies ativados, caso interaja com um dos recursos que você usa em nosso site.
+Esta política é efetiva a partir de 26 November 2025 00:12
+    </string>
+    <string name="Terms_of_use">Termos de Serviço</string>
+    <string name="Terms_of_use_text">
+        1. Termos
+
+Ao acessar o aplicativo Moto Unplugged 2.0, concorda em cumprir estes termos de serviço, todas as leis e regulamentos aplicáveis ​​e concorda que é responsável pelo cumprimento de todas as leis locais aplicáveis. Se você não concordar com algum desses termos, está proibido de usar ou acessar este aplicativo. Os materiais contidos neste site são protegidos pelas leis de direitos autorais e marcas comerciais aplicáveis.
+
+2. Uso de Licença
+
+É concedida permissão para baixar temporariamente uma cópia dos materiais (informações ou software) do aplicativo Moto Unplugged 2.0 , apenas para visualização transitória pessoal e não comercial. Esta é a concessão de uma licença, não uma transferência de título e, sob esta licença, você não pode: modificar ou copiar os materiais; usar os materiais para qualquer finalidade comercial ou para exibição pública (comercial ou não comercial); tentar descompilar ou fazer engenharia reversa de qualquer software contido no site Moto Unplugged 2.0; remover quaisquer direitos autorais ou outras notações de propriedade dos materiais; ou transferir os materiais para outra pessoa ou \'espelhe\' os materiais em qualquer outro servidor.Esta licença será automaticamente rescindida se você violar alguma dessas restrições e poderá ser rescindida por Moto Unplugged 2.0 a qualquer momento. Ao encerrar a visualização desses materiais ou após o término desta licença, você deve apagar todos os materiais baixados em sua posse, seja em formato eletrónico ou impresso.
+
+3. Isenção de responsabilidade
+
+Os materiais no site da Moto Unplugged 2.0 são fornecidos \'como estão\'. Moto Unplugged 2.0 não oferece garantias, expressas ou implícitas, e, por este meio, isenta e nega todas as outras garantias, incluindo, sem limitação, garantias implícitas ou condições de comercialização, adequação a um fim específico ou não violação de propriedade intelectual ou outra violação de direitos. Além disso, o Moto Unplugged 2.0 não garante ou faz qualquer representação relativa à precisão, aos resultados prováveis ​​ou à confiabilidade do uso dos materiais em seu site ou de outra forma relacionado a esses materiais ou em sites vinculados a este site.
+
+4. Limitações
+
+Em nenhum caso o Moto Unplugged 2.0 ou seus fornecedores serão responsáveis por quaisquer danos (incluindo, sem limitação, danos por perda de dados ou lucro ou devido a interrupção dos negócios) decorrentes do uso ou da incapacidade de usar os materiais em Moto Unplugged 2.0, mesmo que Moto Unplugged 2.0 ou um representante autorizado da Moto Unplugged 2.0 tenha sido notificado oralmente ou por escrito da possibilidade de tais danos. Como algumas jurisdições não permitem limitações em garantias implícitas, ou limitações de responsabilidade por danos consequentes ou incidentes, essas limitações podem não se aplicar a você.
+
+5. Precisão dos materiais
+
+Os materiais exibidos no aplicativo do Moto Unplugged 2.0 podem incluir erros técnicos, tipográficos ou fotográficos. O Moto Unplugged 2.0 não garante que qualquer material em seu aplicativo seja preciso, completo ou atual. O Moto Unplugged 2.0 pode fazer alterações nos materiais contidos em seu aplicativo a qualquer momento, sem aviso prévio. No entanto, o Moto Unplugged 2.0 não se compromete a atualizar os materiais.
+
+6. Links
+
+O Moto Unplugged 2.0 não analisou todos os sites vinculados ao seu site e não é responsável pelo conteúdo de nenhum site vinculado. A inclusão de qualquer link não implica endosso por Moto Unplugged 2.0 do aplicativo. O uso de qualquer site vinculado é por conta e risco do usuário.Modificações o Moto Unplugged 2.0 pode revisar estes termos de serviço do site a qualquer momento, sem aviso prévio. Ao usar este aplicativo, você concorda em ficar vinculado à versão atual destes termos de serviço. Lei aplicável Estes termos e condições são regidos e interpretados de acordo com as leis do Moto Unplugged 2.0 e você se submete irrevogavelmente à jurisdição exclusiva dos tribunais naquele estado ou localidade.
+
+    </string>
 
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.1"
+agp = "8.9.0"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.0"
+agp = "8.10.1"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"


### PR DESCRIPTION
## PR: Add Terms and Conditions Screen With Navigation and UI Enhancements


This Pull Request introduces the complete Terms & Conditions screen into the authentication flow.
It includes UI structure, scroll support, text formatting, and a custom gradient “Back” button.
Additionally, navigation support has been added so the Register screen can open the Terms & Conditions screen and return without losing its previous state.
 

### Features Added

feat: Created the full TermsAndConditionsScreen with:

- Header title

- Privacy Policy section

- Terms of Use section

- Long-text support with vertical scroll

- Gradient rounded “Back” button

feat: Added navigation support so the Register screen can open the Terms & Conditions screen.

feat: Ensured that returning from the Terms screen preserves all RegisterScreen input state.

### Improvements

- Updated Register screen to call onNavigateToTermsAndConditions().

- Ensured onBack() from the Terms screen properly returns to the previous screen.

- Included preview support for the screen.

### Tech Details

- Used verticalScroll(rememberScrollState()) to support long content.

- Gradient button implemented using:

- Brush.horizontalGradient()

- RoundedCornerShape(50.dp)

- Included dependency-free layout (only composables).

- Ensured full screen filling using Surface + Column.

### Checklist

- Created TermsAndConditionsScreen composable

- Added navigation entry for the screen

- Connected the Register screen to open the Terms screen

- Implemented Back navigation returning to previous state

- Added Preview for development