### PR TITLE
Feat/activate focus mode

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -2,24 +2,8 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="app">
+      <SelectionState runConfigName="App">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-10-22T23:47:55.092356986Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/home/aluno/.android/avd/Medium_Phone.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection>
-          <targets>
-            <Target type="DEFAULT_BOOT">
-              <handle>
-                <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Alien\.android\avd\Pixel_API_29.avd" />
-              </handle>
-            </Target>
-          </targets>
-        </DialogSelection>
       </SelectionState>
     </selectionStates>
   </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,9 @@ dependencies {
     //implementação material extended
     implementation("androidx.compose.material:material-icons-extended: 2.6.0")
 
+    //implementação do datastore
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.material.icons.extended.android)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
 
 
     <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
-
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
-
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.INTERNET"/>
-
-
-
-
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 
     <application
@@ -37,7 +32,12 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
         </activity>
+        <service
+            android:name=".services.FocusModeService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/motounplugged/MotoUnpluggedApplication.kt
+++ b/app/src/main/java/com/example/motounplugged/MotoUnpluggedApplication.kt
@@ -1,6 +1,7 @@
 package com.example.motounplugged
 
 import android.app.Application
+import com.example.motounplugged.di.dataStoreModule
 import com.example.motounplugged.di.databaseModule
 import com.example.motounplugged.di.repositoryModule
 import com.example.motounplugged.di.viewModelModule
@@ -14,7 +15,9 @@ class MotoUnpluggedApplication : Application() {
 
         startKoin{
             androidContext(this@MotoUnpluggedApplication)
-            modules(listOf(databaseModule,repositoryModule, viewModelModule,useCaseModule))
+            modules(listOf(databaseModule,repositoryModule, viewModelModule,useCaseModule,
+                dataStoreModule
+            ))
         }
     }
 

--- a/app/src/main/java/com/example/motounplugged/database/datastore/FocusDataStore.kt
+++ b/app/src/main/java/com/example/motounplugged/database/datastore/FocusDataStore.kt
@@ -1,0 +1,51 @@
+package com.example.motounplugged.database.datastore
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private const val DATASTORE_NAME = "focus_preferences"
+
+val Context.focusDataStore by preferencesDataStore(
+    name = DATASTORE_NAME
+)
+
+object FocusKeys {
+    val FOCUS_ACTIVE = booleanPreferencesKey("focus_active")
+    val FOCUS_PROFILE_ID = longPreferencesKey("focus_profile_id")
+    val FOCUS_END_TIME = longPreferencesKey("focus_end_time")
+    val FOCUS_PASSWORD_REQUIRED = booleanPreferencesKey("focus_password_required")
+
+}
+
+class FocusDataStore(private val context: Context) {
+
+    val isFocusActive: Flow<Boolean> =
+        context.focusDataStore.data.map {
+            it[FocusKeys.FOCUS_ACTIVE] ?: false
+        }
+
+    suspend fun setFocusActive(
+        active: Boolean,
+        profileId: Long? = null,
+        endTime: Long? = null,
+        passwordRequired: Boolean = false
+    ) {
+        context.focusDataStore.edit { prefs ->
+            prefs[FocusKeys.FOCUS_ACTIVE] = active
+            prefs[FocusKeys.FOCUS_PASSWORD_REQUIRED] = passwordRequired
+            profileId?.let { prefs[FocusKeys.FOCUS_PROFILE_ID] = it }
+            endTime?.let { prefs[FocusKeys.FOCUS_END_TIME] = it }
+        }
+    }
+
+    suspend fun clearFocus() {
+        context.focusDataStore.edit { prefs ->
+            prefs.clear()
+        }
+    }
+}

--- a/app/src/main/java/com/example/motounplugged/di/KoinModules.kt
+++ b/app/src/main/java/com/example/motounplugged/di/KoinModules.kt
@@ -2,6 +2,7 @@ package com.example.motounplugged.di
 
 import androidx.room.Room
 import com.example.motounplugged.database.MotoUnpluggedDataBase
+import com.example.motounplugged.database.datastore.FocusDataStore
 import com.example.motounplugged.repositories.BlockedAppsRepository
 import com.example.motounplugged.database.entities.ProfilesEntity
 import com.example.motounplugged.domain.usecase.GetInstalledAppsUseCase
@@ -44,6 +45,13 @@ val databaseModule = module {
     single { get<MotoUnpluggedDataBase>().blockedAppsDao() }
 
 }
+// Dados do DataStore
+val dataStoreModule = module {
+    single {
+        FocusDataStore(androidContext())
+    }
+
+}
 
 // --- Repositórios ---
 val repositoryModule = module {
@@ -77,7 +85,7 @@ val viewModelModule = module {
         RegisterScreenViewModel(get())
     }
     viewModel {
-        HomeScreenViewModel(get(), get())
+        HomeScreenViewModel(get(), get(), get())
     }
     /*viewModel{
         LoginScreenViewModel(get())

--- a/app/src/main/java/com/example/motounplugged/services/FocusActions.kt
+++ b/app/src/main/java/com/example/motounplugged/services/FocusActions.kt
@@ -1,0 +1,8 @@
+package com.example.motounplugged.services
+
+object FocusActions {
+
+    const val ACTION_START = "com.example.motounplugged.action.START_FOCUS"
+    const val ACTION_STOP = "com.example.motounplugged.action.STOP_FOCUS"
+
+}

--- a/app/src/main/java/com/example/motounplugged/services/FocusModeService.kt
+++ b/app/src/main/java/com/example/motounplugged/services/FocusModeService.kt
@@ -1,0 +1,171 @@
+package com.example.motounplugged.services
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.example.motounplugged.R
+import com.example.motounplugged.database.datastore.FocusDataStore
+import com.example.motounplugged.utils.NotificationsUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+class FocusModeService : Service() {
+
+    private val serviceScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private lateinit var focusDataStore: FocusDataStore
+    private var focusJob: Job? = null
+    private var focusEndTime: Long = 0L
+
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        focusDataStore = FocusDataStore(applicationContext)
+    }
+
+    private fun createNotificationChannel() {
+        Log.d("FOCUS_DEBUG", "startForegroundNotification()")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                NotificationsUtils.CHANNEL_ID,
+                "Modo Foco",
+                NotificationManager.IMPORTANCE_LOW
+            )
+            val nm = getSystemService(NotificationManager::class.java)
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.d("FOCUS_DEBUG", "Service iniciado. action=${intent?.action}")
+        when (intent?.action) {
+            FocusActions.ACTION_START -> {
+
+                startFocus(
+                    profileId = intent.getLongExtra("profileId", -1L),
+                    durationMinutes = intent.getIntExtra("durationMinutes", 0),
+                    interruptions = intent.getBooleanExtra("interruptions", true),
+                    passwordRequired = intent.getBooleanExtra("passwordRequired", false)
+                )
+            }
+            FocusActions.ACTION_STOP -> {
+                Log.d("FOCUS_DEBUG", "STOP recebido")
+                stopFocus()
+            }
+        }
+
+        return START_NOT_STICKY
+    }
+
+    private fun startFocus(
+        profileId: Long,
+        durationMinutes: Int,
+        interruptions: Boolean,
+        passwordRequired: Boolean
+    ) {
+        createNotificationChannel()
+        startForegroundNotification()
+        // evita múltiplos focos
+        focusJob?.cancel()
+
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (nm.isNotificationPolicyAccessGranted && interruptions) {
+            nm.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_NONE)
+        }
+
+        val focusEndTime =
+            System.currentTimeMillis() + durationMinutes * 60_000L
+
+        focusJob = serviceScope.launch {
+            focusDataStore.setFocusActive(
+                active = true,
+                profileId = profileId,
+                endTime = focusEndTime,
+                passwordRequired = passwordRequired
+            )
+
+            while (true) {
+                val remaining = focusEndTime - System.currentTimeMillis()
+
+                if (remaining <= 0) {
+                    stopFocus()
+                    break
+                }
+
+                updateNotification(remaining)
+                kotlinx.coroutines.delay(1_000L) // atualiza a cada segundo
+            }
+        }
+    }
+
+    private fun stopFocus() {
+        focusJob?.cancel()
+
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        if (nm.isNotificationPolicyAccessGranted) {
+            nm.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL)
+        }
+
+        serviceScope.launch {
+            focusDataStore.clearFocus()
+        }
+
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    private fun startForegroundNotification() {
+        val notification = NotificationsUtils.createFocusNotification(this)
+        startForeground(
+            NotificationsUtils.NOTIFICATION_ID,
+            notification
+        )
+    }
+
+    override fun onDestroy() {
+        focusJob?.cancel()
+        super.onDestroy()
+    }
+
+    private fun formatRemainingTime(ms: Long): String {
+        val totalSeconds = ms / 1000
+        val minutes = totalSeconds / 60
+        val seconds = totalSeconds % 60
+        return String.format("%02d:%02d", minutes, seconds)
+    }
+
+    private fun updateNotification(remainingMs: Long) {
+        val notification = NotificationCompat.Builder(
+            this,
+            NotificationsUtils.CHANNEL_ID
+        )
+            .setSmallIcon(R.drawable.img)
+            .setContentTitle("Modo foco ativo")
+            .setContentText("Tempo restante: ${formatRemainingTime(remainingMs)}")
+            .setOngoing(true)
+            .build()
+
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(NotificationsUtils.NOTIFICATION_ID, notification)
+    }
+}
+
+
+
+

--- a/app/src/main/java/com/example/motounplugged/ui/features/createprofile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/createprofile/CreateProfileScreen.kt
@@ -252,17 +252,12 @@ private fun CreateProfileContent(
             subtitle = "Gerenciar alertas e notificações",
             checked = uiState.interruptions,
             onCheckedChange = {
-                val notificationsManager =
-                    context.getSystemService(Context.NOTIFICATION_SERVICE) as
-                            NotificationManager
-                if (!notificationsManager.isNotificationPolicyAccessGranted){
-                    // Força o app a abrir o dnd para permissão
-                    try {
-                        notificationsManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_NONE)
-                    }catch (e: SecurityException){
-                    }
+                val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+                if (!nm.isNotificationPolicyAccessGranted) {
                     context.startActivity(
                         Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     )
                 } else {
                     onEvent(CreateProfileEvent.OnInterruptionsClick(it))

--- a/app/src/main/java/com/example/motounplugged/ui/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/home/HomeScreen.kt
@@ -1,5 +1,14 @@
 package com.example.motounplugged.ui.features.home
 
+import android.app.Activity
+import android.app.KeyguardManager
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.util.Log
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
@@ -14,23 +23,31 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
 import androidx.navigation.NavHostController
 import com.example.motounplugged.R
+import com.example.motounplugged.database.entities.ProfilesEntity
+import com.example.motounplugged.models.Profile
+import com.example.motounplugged.services.FocusActions
+import com.example.motounplugged.services.FocusModeService
 import com.example.motounplugged.ui.navigation.AppScreens
 
 @Composable
@@ -41,6 +58,76 @@ fun HomeScreen(
 ){
 
     val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val isFocusActive by viewModel.isFocusActive.collectAsState()
+
+    val keyguardManager =
+        context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+
+
+    fun startFocusService(context: Context, uiState: HomeUiState) {
+        val profile = uiState.activeProfile ?: return
+
+        val intent = Intent(context, FocusModeService::class.java).apply {
+            action = FocusActions.ACTION_START
+            putExtra("profileId", profile.idProfile)
+            putExtra("durationMinutes", profile.duration)
+            putExtra("interruptions", profile.interruptions)
+            putExtra("passwordRequired", profile.passwordRequired)
+        }
+
+        ContextCompat.startForegroundService(context, intent)
+    }
+
+    fun stopFocusService(context: Context) {
+        val intent = Intent(context, FocusModeService::class.java).apply {
+            action = FocusActions.ACTION_STOP
+        }
+        context.startService(intent)
+    }
+
+    val unlockLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            stopFocusService(context)
+        }
+    }
+
+    fun requestDeviceAuthentication() {
+        if (!keyguardManager.isDeviceSecure) {
+            // Aqui você pode usar Snackbar / Toast
+            Toast.makeText(
+                context,
+                "Defina uma senha no dispositivo para desativar o modo foco",
+                Toast.LENGTH_LONG
+            ).show()
+            return
+        }
+
+        val intent = keyguardManager.createConfirmDeviceCredentialIntent(
+            "Confirmar identidade",
+            "Digite a senha do dispositivo para sair do modo foco"
+        )
+
+        unlockLauncher.launch(intent)
+    }
+
+    // Permissão para notficaições
+    val notificationPermissionLauncher =
+        rememberLauncherForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { granted ->
+            if (granted) {
+                startFocusService(context, uiState)
+            } else {
+                Toast.makeText(
+                    context,
+                    "Permissão de notificação é necessária para o modo foco",
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+        }
 
     Column (
         modifier = modifier
@@ -135,7 +222,7 @@ fun HomeScreen(
                     Spacer(Modifier.height(8.dp))
 
                     Text(
-                        text = "Duração: ${profile!!.duration} min",
+                        text = "Duração: ${profile.duration} min",
                         fontSize = 14.sp,
                         fontStyle = FontStyle.Normal,
                         color = Color.Black
@@ -166,10 +253,37 @@ fun HomeScreen(
                     Spacer(Modifier.height(16.dp))
 
                     ElevatedButton(
-                        onClick = { viewModel.onActivateProfile() },
-                        modifier = Modifier.fillMaxWidth()
+                        onClick = {
+                            if (isFocusActive) {
+                                if (uiState.activeProfile!!.passwordRequired) {
+                                    requestDeviceAuthentication()
+                                } else {
+                                    stopFocusService(context)
+                                }
+                            } else {
+                                if (ContextCompat.checkSelfPermission(
+                                        context,
+                                        android.Manifest.permission.POST_NOTIFICATIONS
+                                    ) != PackageManager.PERMISSION_GRANTED
+                                ) {
+                                    notificationPermissionLauncher.launch(
+                                        android.Manifest.permission.POST_NOTIFICATIONS
+                                    )
+                                }
+
+                                startFocusService(context, uiState)
+                            }
+                        } ,
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.elevatedButtonColors(
+                                containerColor = if (!isFocusActive) Color.hsv(205f,1f, 0.95f) else Color.Gray,
+                                contentColor = Color.White
+                        )
                     ) {
-                        Text("Ativar",color = Color.DarkGray)
+                        Text(
+                            text = if (isFocusActive) "Desativar" else "Ativar",
+                            color = Color.White
+                        )
                     }
 
                 }
@@ -322,7 +436,7 @@ fun HomeScreen(
                     fontWeight = FontWeight.Bold,
                     fontSize = 10.sp,
                     fontStyle = FontStyle.Normal,
-                    color = Color.DarkGray,
+                    color = Color.Black,
                     modifier = Modifier
                         .padding(1.dp)
                 )
@@ -340,18 +454,16 @@ fun HomeScreen(
                     fontWeight = FontWeight.Bold,
                     fontSize = 10.sp,
                     fontStyle = FontStyle.Normal,
-                    color = Color.DarkGray,
+                    color = Color.Black,
                     modifier = Modifier
                         .padding(1.dp)
                 )
             }
         }
 
-
-
-
-
     }
+
 }
+
 
 

--- a/app/src/main/java/com/example/motounplugged/ui/features/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/example/motounplugged/ui/features/home/HomeScreenViewModel.kt
@@ -1,14 +1,20 @@
 package com.example.motounplugged.ui.features.home
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.motounplugged.database.datastore.FocusDataStore
 import com.example.motounplugged.database.entities.ProfilesEntity
 import com.example.motounplugged.database.entities.SessionsEntity
 import com.example.motounplugged.repositories.ProfileRepository
 import com.example.motounplugged.repositories.SessionsRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -20,14 +26,24 @@ data class HomeUiState(
     val errorMessage: String? = null
 )
 
+sealed class HomeUiEvent {
+    data object StartFocusMode : HomeUiEvent()
+    data object RequestStopFocus : HomeUiEvent()
+}
 
 class HomeScreenViewModel(
     private val profileRepository: ProfileRepository,
-    private val sessionRepository: SessionsRepository
+    private val sessionRepository: SessionsRepository,
+    private val focusDataStore: FocusDataStore
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+    private val _uiEvent = MutableSharedFlow<HomeUiEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
+    //DataStore
+    val isFocusActive = focusDataStore.isFocusActive
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), false)
 
     init {
         loadHome()
@@ -76,6 +92,16 @@ class HomeScreenViewModel(
     }
 
     fun onActivateProfile() {
-        // aqui futuramente você ativa o modo foco
+        if (_uiState.value.activeProfile == null) return
+
+        viewModelScope.launch {
+            _uiEvent.emit(HomeUiEvent.StartFocusMode)
+        }
+    }
+
+    fun onDeactivateFocus() {
+        viewModelScope.launch {
+            _uiEvent.emit(HomeUiEvent.RequestStopFocus)
+        }
     }
 }

--- a/app/src/main/java/com/example/motounplugged/utils/NotificationsUtils.kt
+++ b/app/src/main/java/com/example/motounplugged/utils/NotificationsUtils.kt
@@ -1,0 +1,24 @@
+package com.example.motounplugged.utils
+
+import android.app.Notification
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import com.example.motounplugged.R
+
+object NotificationsUtils {
+
+    const val CHANNEL_ID = "focus_mode_channel"
+    const val NOTIFICATION_ID = 1
+
+    fun createFocusNotification(context: Context): Notification {
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_focus_notification) //  correto
+            .setContentTitle("Modo foco ativo")
+            .setContentText("O foco está em execução")
+            .setOngoing(true)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+    }
+}
+

--- a/app/src/main/res/drawable/ic_focus_notification.xml
+++ b/app/src/main/res/drawable/ic_focus_notification.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24"
+        android:tint="@android:color/white">
+
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M12,2L4,6v6c0,5 3.8,9.7 8,10 4.2,-0.3 8,-5 8,-10V6z" />
+    </vector>
+</selector>


### PR DESCRIPTION
# 🚀 PR: Implementação do Modo Foco (Service, Notificações, DND e Proteção por Senha)

## 📌 Descrição
Este PR implementa o **Modo Foco** no aplicativo **Moto Unplugged**, garantindo execução em segundo plano via **Foreground Service**, notificação persistente, controle de **Interrupções (DND)**, **proteção por senha do dispositivo** para desativação e integração completa com a **HomeScreen**.

---

## ✨ Principais Alterações

### 1️⃣ FocusModeService (Foreground Service)
- Criação do serviço responsável pelo ciclo de vida do Modo Foco.
- Ações suportadas:
  - `ACTION_START`: inicia o foco.
  - `ACTION_STOP`: encerra o foco.
- Uso de `CoroutineScope` com `Job` para controle de duração.
- Persistência do estado via `FocusDataStore`.

**Responsabilidades do Service:**
- Ativar/desativar DND.
- Controlar a duração do foco.
- Exibir notificação em foreground.
- Limpar estado ao finalizar.

---

### 2️⃣ Persistência de Estado (DataStore)
O `FocusDataStore` passa a salvar:
- `active` (Boolean)
- `profileId`
- `endTime`
- `passwordRequired`

Permite:
- Recuperar estado após fechar o app.
- UI reativa na HomeScreen.

---

### 3️⃣ Notificações (Foreground)
Criação de utilitário para notificação persistente:

```kotlin
object NotificationsUtils {
    const val CHANNEL_ID = "focus_mode_channel"
    const val NOTIFICATION_ID = 1

    fun createFocusNotification(context: Context): Notification {
        return NotificationCompat.Builder(context, CHANNEL_ID)
            .setSmallIcon(R.drawable.img)
            .setContentTitle("Modo foco ativo")
            .setContentText("O foco está em execução")
            .setOngoing(true)
            .build()
    }
}
